### PR TITLE
chore: limpiar y corregir .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-APP_NAME=Macro
+APP_NAME=Nominapp
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
@@ -10,7 +10,6 @@ APP_FALLBACK_LOCALE=en
 APP_FAKER_LOCALE=es_PY
 
 APP_MAINTENANCE_DRIVER=file
-# APP_MAINTENANCE_STORE=database
 
 PHP_CLI_SERVER_WORKERS=4
 
@@ -24,7 +23,7 @@ LOG_LEVEL=debug
 DB_CONNECTION=mysql
 DB_HOST=localhost
 DB_PORT=3306
-DB_DATABASE=macro
+DB_DATABASE=nominapp
 DB_USERNAME=root
 DB_PASSWORD=
 
@@ -39,14 +38,6 @@ FILESYSTEM_DISK=local
 QUEUE_CONNECTION=database
 
 CACHE_STORE=database
-# CACHE_PREFIX=
-
-MEMCACHED_HOST=127.0.0.1
-
-REDIS_CLIENT=phpredis
-REDIS_HOST=127.0.0.1
-REDIS_PASSWORD=null
-REDIS_PORT=6379
 
 MAIL_MAILER=log
 MAIL_SCHEME=null
@@ -56,12 +47,6 @@ MAIL_USERNAME=null
 MAIL_PASSWORD=null
 MAIL_FROM_ADDRESS="hello@example.com"
 MAIL_FROM_NAME="${APP_NAME}"
-
-AWS_ACCESS_KEY_ID=
-AWS_SECRET_ACCESS_KEY=
-AWS_DEFAULT_REGION=us-east-1
-AWS_BUCKET=
-AWS_USE_PATH_STYLE_ENDPOINT=false
 
 # Configuración de Asistencias
 # Tiempo en minutos después de la hora de entrada esperada para marcar ausencia automática
@@ -73,7 +58,7 @@ ADMIN_NAME="Administrador"
 ADMIN_EMAIL=admin@example.com
 ADMIN_PASSWORD=
 
-VITE_APP_NAME="${APP_NAME}"GOOGLE_MAPS_API_KEY=
+VITE_APP_NAME="${APP_NAME}"
 
-# Configuración de Google Maps. 
+# Requerida para el mapa de sucursales (cheesegrits/filament-google-maps)
 GOOGLE_MAPS_API_KEY=


### PR DESCRIPTION
- Renombrar APP_NAME y DB_DATABASE de "macro" a "nominapp"
- Corregir línea rota donde VITE_APP_NAME y GOOGLE_MAPS_API_KEY estaban pegados
- Eliminar duplicado de GOOGLE_MAPS_API_KEY
- Eliminar secciones no utilizadas: Memcached, Redis y AWS

https://claude.ai/code/session_01FuB5EtMZqm3KKN9pqspSzW