### PR TITLE
fix: remove Content-Type header from deploy webhook curl (HTTP 415)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,8 +29,6 @@ jobs:
             --max-time 300 \
             -X POST \
             -H "X-Deploy-Token: ${{ secrets.DEPLOY_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            -d '{}' \
             https://nominapp.sedacosmetica.com/deploy.php)
 
           # Print the deploy log from the server response


### PR DESCRIPTION
El nginx del servidor rechaza el `Content-Type: application/json` con HTTP 415. El `deploy.php` no usa el body de la request, así que se elimina el header y el `-d '{}'` del curl.

https://claude.ai/code/session_01DkPqvi3dsrDQW1snBbf1mP

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkPqvi3dsrDQW1snBbf1mP)_