### PR TITLE
fix: drop unique index before inserts in contract_templates migration

### DIFF
--- a/database/migrations/2026_06_12_000001_add_company_id_to_contract_templates_table.php
+++ b/database/migrations/2026_06_12_000001_add_company_id_to_contract_templates_table.php
@@ -18,6 +18,11 @@ return new class extends Migration
         $existingTemplates = DB::table('contract_templates')->whereNull('company_id')->get();
         $companies = DB::table('companies')->where('is_active', 1)->orderBy('id')->pluck('id');
 
+        // Dropar el índice único en type ANTES de los inserts para evitar violaciones
+        Schema::table('contract_templates', function (Blueprint $table) {
+            $table->dropUnique(['type']);
+        });
+
         if ($companies->isNotEmpty() && $existingTemplates->isNotEmpty()) {
             // Asignar las filas originales a la primera empresa
             DB::table('contract_templates')
@@ -43,7 +48,6 @@ return new class extends Migration
         }
 
         Schema::table('contract_templates', function (Blueprint $table) {
-            $table->dropUnique(['type']);
             $table->unique(['company_id', 'type']);
         });
     }


### PR DESCRIPTION
La migration intentaba insertar filas con `type` duplicado mientras el índice único en `type` todavía estaba activo → error 1062.

Fix: mover el `dropUnique(['type'])` **antes** de los inserts, y dejar solo el `unique(['company_id', 'type'])` al final.

https://claude.ai/code/session_01DkPqvi3dsrDQW1snBbf1mP

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkPqvi3dsrDQW1snBbf1mP)_