### PR TITLE
fix: use Content-Type text/plain for deploy webhook (nginx 415)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,8 @@ jobs:
             --max-time 300 \
             -X POST \
             -H "X-Deploy-Token: ${{ secrets.DEPLOY_TOKEN }}" \
+            -H "Content-Type: text/plain" \
+            -d '' \
             https://nominapp.sedacosmetica.com/deploy.php)
 
           # Print the deploy log from the server response


### PR DESCRIPTION
nginx/openresty bloquea POST sin Content-Type (415). `application/json` también está bloqueado. `text/plain` con body vacío es aceptado.

https://claude.ai/code/session_01DkPqvi3dsrDQW1snBbf1mP

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkPqvi3dsrDQW1snBbf1mP)_