### PR TITLE
feat: mejoras al módulo Plantillas de Contratos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -555,6 +555,18 @@ return response()->file($path, [
 ]);
 ```
 
+**`$pdf->stream()` y caché del navegador**
+`$pdf->stream()` tampoco agrega headers no-cache por defecto. El mismo principio aplica — capturar el response y agregar los headers antes de retornarlo:
+
+```php
+$response = $pdf->stream("nombre_archivo.pdf");
+$response->headers->set('Cache-Control', 'no-store, no-cache, must-revalidate');
+$response->headers->set('Pragma', 'no-cache');
+return $response;
+```
+
+Aplica siempre que el PDF se genera en tiempo real a partir de datos que pueden cambiar (plantillas editables, recibos regenerados, etc.).
+
 **`$this->js("window.open(url, '_blank')")` para URLs dinámicas post-modal**
 Cuando la URL del PDF depende de datos del formulario del modal (ej. selección de modo), no se puede usar `->url()->openUrlInNewTab()` (que es estático). En su lugar:
 
@@ -1149,6 +1161,45 @@ public function mount(): void
 ```
 
 Esto significa que si el usuario limpia explícitamente el filtro (session guarda null), al recargar la página el filtro vuelve a 'active'. Para reportes con un default intencional, este comportamiento es aceptable.
+
+### Migraciones DDL en Laravel 12 — sin Doctrine DBAL
+
+Laravel 12 eliminó la dependencia de Doctrine DBAL. Métodos como `getDoctrineSchemaManager()`, `listTableIndexes()` y similares ya no existen. Las operaciones DDL idempotentes deben hacerse con `try/catch` y guards de Schema:
+
+**Agregar columna (idempotente):**
+```php
+if (! Schema::hasColumn('tabla', 'columna')) {
+    Schema::table('tabla', function (Blueprint $table) {
+        $table->foreignId('columna')->nullable()->constrained('otras_tablas');
+    });
+}
+```
+
+**Eliminar / agregar índice único (idempotente):**
+```php
+// ❌ No existe en Laravel 12
+$sm = Schema::getConnection()->getDoctrineSchemaManager();
+$indexes = $sm->listTableIndexes('tabla');
+
+// ✅ Correcto — try/catch para idempotencia
+try {
+    Schema::table('tabla', function (Blueprint $table) {
+        $table->dropUnique(['columna']);
+    });
+} catch (\Throwable $e) {
+    // El índice ya fue eliminado en un deploy anterior parcial — continuar
+}
+
+try {
+    Schema::table('tabla', function (Blueprint $table) {
+        $table->unique(['col1', 'col2']);
+    });
+} catch (\Throwable $e) {
+    // El índice ya existe — continuar
+}
+```
+
+El `try/catch` es necesario también para idempotencia en caso de deploys parciales (migración que falló a mitad y dejó la BD en estado intermedio).
 
 ### Diferencias de fechas con Carbon 3 (Laravel 12)
 

--- a/app/Filament/Resources/ContractResource.php
+++ b/app/Filament/Resources/ContractResource.php
@@ -346,20 +346,10 @@ class ContractResource extends Resource
                     ])
                     ->visible(fn (string $operation) => $operation === 'edit'),
 
-                Section::make('Notas')
-                    ->schema([
-                        Textarea::make('notes')
-                            ->label('Observaciones')
-                            ->placeholder('Notas adicionales sobre el contrato...')
-                            ->rows(2)
-                            ->columnSpanFull(),
-                    ]),
-
                 Section::make('Cláusulas Adicionales')
                     ->description('Cláusulas específicas para este contrato, que se agregan al final del cuerpo de la plantilla')
                     ->icon('heroicon-o-document-plus')
                     ->collapsible()
-                    ->collapsed(fn (?Model $record) => $record === null || ! $record->additional_clauses)
                     ->schema([
                         RichEditor::make('additional_clauses')
                             ->label('Cláusulas adicionales')
@@ -599,16 +589,6 @@ class ContractResource extends Resource
                         ->placeholder('Sin cláusulas adicionales'),
                 ])
                 ->visible(fn ($record) => filled($record->additional_clauses)),
-
-            InfoSection::make('Notas')
-                ->collapsible()
-                ->schema([
-                    TextEntry::make('notes')
-                        ->label('')
-                        ->placeholder('Sin notas')
-                        ->columnSpanFull(),
-                ])
-                ->visible(fn (Contract $record) => ! empty($record->notes)),
 
             InfoSection::make('Registro')
                 ->icon('heroicon-o-information-circle')

--- a/app/Filament/Resources/ContractTemplateResource.php
+++ b/app/Filament/Resources/ContractTemplateResource.php
@@ -249,19 +249,25 @@ class ContractTemplateResource extends Resource
                     ->icon(fn ($state) => $state ? Contract::getTypeIcon($state) : null),
 
                 TextColumn::make('sections_configured')
-                    ->label('Secciones configuradas')
-                    ->getStateUsing(function (ContractTemplate $record): string {
-                        $sections = collect([
-                            $record->intro_text ? 'Intro' : null,
-                            $record->body ? 'Cláusulas' : null,
-                            $record->closing_text ? 'Cierre' : null,
-                            $record->signature_notes ? 'Firmas' : null,
-                        ])->filter()->implode(', ');
+                    ->label('Secciones')
+                    ->getStateUsing(function (ContractTemplate $record): HtmlString {
+                        $sections = [
+                            'Intro'     => filled($record->intro_text),
+                            'Cláusulas' => filled($record->body),
+                            'Cierre'    => filled($record->closing_text),
+                            'Firmas'    => filled($record->signature_notes),
+                        ];
 
-                        return $sections ?: 'Sin personalizar';
-                    })
-                    ->badge()
-                    ->color(fn (string $state): string => $state === 'Sin personalizar' ? 'gray' : 'success'),
+                        $badges = collect($sections)->map(function (bool $filled, string $label): string {
+                            $color = $filled
+                                ? 'background:rgb(var(--color-success-100));color:rgb(var(--color-success-700));'
+                                : 'background:rgb(var(--color-warning-100));color:rgb(var(--color-warning-700));';
+
+                            return "<span style=\"{$color}display:inline-block;padding:1px 8px;border-radius:9999px;font-size:0.75rem;font-weight:500;margin:1px 2px\">{$label}</span>";
+                        })->implode('');
+
+                        return new HtmlString("<div style=\"display:flex;flex-wrap:wrap;gap:2px\">{$badges}</div>");
+                    }),
 
                 TextColumn::make('body')
                     ->label('Vista previa (cláusulas)')

--- a/app/Filament/Resources/ContractTemplateResource.php
+++ b/app/Filament/Resources/ContractTemplateResource.php
@@ -17,6 +17,7 @@ use Filament\Forms\Components\Toggle;
 use Filament\Forms\Form;
 use Filament\Forms\Set;
 use Filament\Resources\Resource;
+use Filament\Tables\Actions\Action as TableAction;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
@@ -274,6 +275,12 @@ class ContractTemplateResource extends Resource
                     ->sortable(),
             ])
             ->actions([
+                TableAction::make('preview_pdf')
+                    ->label('Vista Previa')
+                    ->icon('heroicon-o-eye')
+                    ->color('gray')
+                    ->url(fn (ContractTemplate $record) => route('contract-templates.preview', $record))
+                    ->openUrlInNewTab(),
                 EditAction::make()
                     ->label('Editar plantilla')
                     ->icon('heroicon-o-pencil-square')

--- a/app/Filament/Resources/ContractTemplateResource.php
+++ b/app/Filament/Resources/ContractTemplateResource.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources;
 
 use App\Filament\Resources\ContractTemplateResource\Pages;
+use App\Filament\Resources\ContractTemplateResource\RelationManagers;
 use App\Models\Company;
 use App\Models\Contract;
 use App\Models\ContractTemplate;
@@ -296,13 +297,24 @@ class ContractTemplateResource extends Resource
     }
 
     /**
+     * @return array<class-string>
+     */
+    public static function getRelations(): array
+    {
+        return [
+            RelationManagers\ContractTemplateAuditsRelationManager::class,
+        ];
+    }
+
+    /**
      * @return array<string, string>
      */
     public static function getPages(): array
     {
         return [
-            'index' => Pages\ListContractTemplates::route('/'),
-            'edit' => Pages\EditContractTemplate::route('/{record}/edit'),
+            'index'  => Pages\ListContractTemplates::route('/'),
+            'view'   => Pages\ViewContractTemplate::route('/{record}'),
+            'edit'   => Pages\EditContractTemplate::route('/{record}/edit'),
         ];
     }
 }

--- a/app/Filament/Resources/ContractTemplateResource/Pages/EditContractTemplate.php
+++ b/app/Filament/Resources/ContractTemplateResource/Pages/EditContractTemplate.php
@@ -3,8 +3,11 @@
 namespace App\Filament\Resources\ContractTemplateResource\Pages;
 
 use App\Filament\Resources\ContractTemplateResource;
+use App\Models\Company;
 use App\Models\ContractTemplate;
 use Filament\Actions\Action;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Get;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\EditRecord;
 
@@ -22,6 +25,78 @@ class EditContractTemplate extends EditRecord
                 ->color('gray')
                 ->url(fn () => route('contract-templates.preview', $this->record))
                 ->openUrlInNewTab(),
+
+            Action::make('copy_to_company')
+                ->label('Copiar a empresa')
+                ->icon('heroicon-o-document-duplicate')
+                ->color('info')
+                ->visible(fn () => Company::active()->where('id', '!=', $this->record->company_id)->exists())
+                ->form([
+                    Select::make('target_company_id')
+                        ->label('Empresa destino')
+                        ->options(fn () => Company::active()
+                            ->where('id', '!=', $this->record->company_id)
+                            ->orderBy('name')
+                            ->pluck('name', 'id')
+                            ->toArray()
+                        )
+                        ->required()
+                        ->live(),
+
+                    \Filament\Forms\Components\Placeholder::make('overwrite_warning')
+                        ->label('')
+                        ->content(function (Get $get): ?string {
+                            $targetId = $get('target_company_id');
+                            if (! $targetId) {
+                                return null;
+                            }
+                            $exists = ContractTemplate::where('company_id', $targetId)
+                                ->where('type', $this->record->type)
+                                ->exists();
+                            if (! $exists) {
+                                return null;
+                            }
+                            $companyName = Company::find($targetId)?->name;
+
+                            return "⚠️ Ya existe una plantilla de tipo \"{$this->record->type}\" en {$companyName}. Se sobreescribirá con el contenido actual.";
+                        })
+                        ->visible(fn (Get $get): bool => filled($get('target_company_id')) &&
+                            ContractTemplate::where('company_id', $get('target_company_id'))
+                                ->where('type', $this->record->type)
+                                ->exists()
+                        ),
+                ])
+                ->modalHeading('Copiar plantilla a otra empresa')
+                ->modalSubmitActionLabel('Copiar')
+                ->action(function (array $data) {
+                    $targetId = $data['target_company_id'];
+
+                    ContractTemplate::updateOrCreate(
+                        ['company_id' => $targetId, 'type' => $this->record->type],
+                        [
+                            'intro_text'                  => $this->record->intro_text,
+                            'body'                        => $this->record->body,
+                            'closing_text'                => $this->record->closing_text,
+                            'signature_notes'             => $this->record->signature_notes,
+                            'document_title'              => $this->record->document_title,
+                            'document_subtitle'           => $this->record->document_subtitle,
+                            'document_art_reference'      => $this->record->document_art_reference,
+                            'signature_employee_label'    => $this->record->signature_employee_label,
+                            'signature_employer_label'    => $this->record->signature_employer_label,
+                            'signature_employer_sublabel' => $this->record->signature_employer_sublabel,
+                            'show_header'                 => $this->record->show_header,
+                            'show_footer'                 => $this->record->show_footer,
+                        ]
+                    );
+
+                    $companyName = Company::find($targetId)?->name;
+
+                    Notification::make()
+                        ->success()
+                        ->title('Plantilla copiada')
+                        ->body("La plantilla fue copiada a {$companyName} correctamente.")
+                        ->send();
+                }),
 
             Action::make('restore_defaults')
                 ->label('Restaurar valores base')

--- a/app/Filament/Resources/ContractTemplateResource/Pages/EditContractTemplate.php
+++ b/app/Filament/Resources/ContractTemplateResource/Pages/EditContractTemplate.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\ContractTemplateResource\Pages;
 
 use App\Filament\Resources\ContractTemplateResource;
+use App\Models\ContractTemplate;
 use Filament\Actions\Action;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\EditRecord;
@@ -21,6 +22,31 @@ class EditContractTemplate extends EditRecord
                 ->color('gray')
                 ->url(fn () => route('contract-templates.preview', $this->record))
                 ->openUrlInNewTab(),
+
+            Action::make('restore_defaults')
+                ->label('Restaurar valores base')
+                ->icon('heroicon-o-arrow-path')
+                ->color('warning')
+                ->requiresConfirmation()
+                ->modalHeading('¿Restaurar todos los textos al valor base?')
+                ->modalDescription('Esto reemplazará el texto de introducción, cuerpo, cierre y notas de firma con el contenido base del sistema. Los campos de presentación (título, subtítulo, etiquetas) no se modificarán. Esta acción no se puede deshacer.')
+                ->modalSubmitActionLabel('Sí, restaurar')
+                ->action(function () {
+                    $this->record->update([
+                        'intro_text'      => ContractTemplate::getDefaultIntroText(),
+                        'body'            => ContractTemplate::getDefaultBodyText(),
+                        'closing_text'    => ContractTemplate::getDefaultClosingText(),
+                        'signature_notes' => ContractTemplate::getDefaultSignatureNotes(),
+                    ]);
+
+                    $this->fillForm();
+
+                    Notification::make()
+                        ->success()
+                        ->title('Textos restaurados')
+                        ->body('Las 4 secciones de texto fueron restauradas al contenido base.')
+                        ->send();
+                }),
 
             Action::make('back')
                 ->label('Volver al listado')

--- a/app/Filament/Resources/ContractTemplateResource/Pages/EditContractTemplate.php
+++ b/app/Filament/Resources/ContractTemplateResource/Pages/EditContractTemplate.php
@@ -133,7 +133,7 @@ class EditContractTemplate extends EditRecord
 
     protected function getRedirectUrl(): string
     {
-        return ContractTemplateResource::getUrl('index');
+        return ContractTemplateResource::getUrl('view', ['record' => $this->record]);
     }
 
     /**

--- a/app/Filament/Resources/ContractTemplateResource/Pages/ViewContractTemplate.php
+++ b/app/Filament/Resources/ContractTemplateResource/Pages/ViewContractTemplate.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Filament\Resources\ContractTemplateResource\Pages;
+
+use App\Filament\Resources\ContractTemplateResource;
+use Filament\Actions\Action;
+use Filament\Resources\Pages\ViewRecord;
+
+/** Vista de detalle de plantilla de contrato con historial de cambios. */
+class ViewContractTemplate extends ViewRecord
+{
+    protected static string $resource = ContractTemplateResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('preview_pdf')
+                ->label('Vista Previa PDF')
+                ->icon('heroicon-o-eye')
+                ->color('gray')
+                ->url(fn () => route('contract-templates.preview', $this->record))
+                ->openUrlInNewTab(),
+
+            Action::make('edit')
+                ->label('Editar')
+                ->icon('heroicon-o-pencil-square')
+                ->url(fn () => ContractTemplateResource::getUrl('edit', ['record' => $this->record])),
+        ];
+    }
+}

--- a/app/Filament/Resources/ContractTemplateResource/RelationManagers/ContractTemplateAuditsRelationManager.php
+++ b/app/Filament/Resources/ContractTemplateResource/RelationManagers/ContractTemplateAuditsRelationManager.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Filament\Resources\ContractTemplateResource\RelationManagers;
+
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Columns\Column;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/** Historial de cambios de la plantilla de contrato via laravel-auditing. */
+class ContractTemplateAuditsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'audits';
+
+    protected static ?string $recordTitleAttribute = 'id';
+
+    public static function getTitle(Model $ownerRecord, string $pageClass): string
+    {
+        return 'Historial de cambios';
+    }
+
+    public static function canViewForRecord(Model $ownerRecord, string $pageClass): bool
+    {
+        return true;
+    }
+
+    private function translateEvent(string $event): string
+    {
+        return match ($event) {
+            'created'  => 'Creado',
+            'updated'  => 'Modificado',
+            'deleted'  => 'Eliminado',
+            'restored' => 'Restaurado',
+            default    => ucfirst($event),
+        };
+    }
+
+    private function eventColor(string $event): string
+    {
+        return match ($event) {
+            'created'  => 'success',
+            'updated'  => 'info',
+            'deleted'  => 'danger',
+            'restored' => 'warning',
+            default    => 'gray',
+        };
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->modifyQueryUsing(fn (Builder $query) => $query->with('user')->orderBy('created_at', 'desc'))
+            ->emptyStateHeading('Sin historial de cambios')
+            ->emptyStateDescription('Los cambios en los textos y configuración de la plantilla aparecerán aquí.')
+            ->columns([
+                Tables\Columns\TextColumn::make('user.name')
+                    ->label('Usuario')
+                    ->placeholder('Sistema')
+                    ->searchable(),
+
+                Tables\Columns\TextColumn::make('event')
+                    ->label('Evento')
+                    ->formatStateUsing(fn (string $state) => $this->translateEvent($state))
+                    ->badge()
+                    ->color(fn (string $state) => $this->eventColor($state)),
+
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label('Fecha y hora')
+                    ->dateTime('d/m/Y H:i')
+                    ->sortable(),
+
+                Tables\Columns\TextColumn::make('old_values')
+                    ->label('Valores anteriores')
+                    ->formatStateUsing(fn (Column $column, $record) => $this->getOwnerRecord()->formatAuditFieldsForPresentation($column->getName(), $record))
+                    ->html()
+                    ->wrap(),
+
+                Tables\Columns\TextColumn::make('new_values')
+                    ->label('Nuevos valores')
+                    ->formatStateUsing(fn (Column $column, $record) => $this->getOwnerRecord()->formatAuditFieldsForPresentation($column->getName(), $record))
+                    ->html()
+                    ->wrap(),
+            ])
+            ->filters([])
+            ->headerActions([])
+            ->actions([])
+            ->bulkActions([]);
+    }
+}

--- a/app/Models/ContractTemplate.php
+++ b/app/Models/ContractTemplate.php
@@ -4,10 +4,28 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\HtmlString;
+use Illuminate\Support\Str;
+use OwenIt\Auditing\Contracts\Auditable;
 
 /** Plantilla de cuerpo/cláusulas por tipo de contrato, con alcance por empresa. */
-class ContractTemplate extends Model
+class ContractTemplate extends Model implements Auditable
 {
+    use \OwenIt\Auditing\Auditable;
+
+    protected array $auditInclude = [
+        'intro_text',
+        'body',
+        'closing_text',
+        'signature_notes',
+        'document_title',
+        'document_subtitle',
+        'signature_employee_label',
+        'signature_employer_label',
+        'signature_employer_sublabel',
+        'show_header',
+        'show_footer',
+    ];
     protected $fillable = [
         'company_id',
         'type',
@@ -147,5 +165,57 @@ class ContractTemplate extends Model
     public static function resolveVariables(string $html, array $values): string
     {
         return str_replace(array_keys($values), array_values($values), $html);
+    }
+
+    /**
+     * Formatea los campos auditados para su presentación en el RelationManager de historial.
+     */
+    public function formatAuditFieldsForPresentation(string $column, mixed $auditRecord): HtmlString
+    {
+        $values = $auditRecord->{$column} ?? [];
+
+        if (empty($values)) {
+            return new HtmlString('<span class="text-gray-400 text-xs">—</span>');
+        }
+
+        $fieldLabels = [
+            'intro_text'                  => 'Introducción',
+            'body'                        => 'Cuerpo / Cláusulas',
+            'closing_text'                => 'Cierre',
+            'signature_notes'             => 'Notas de firma',
+            'document_title'              => 'Título del documento',
+            'document_subtitle'           => 'Subtítulo',
+            'signature_employee_label'    => 'Etiqueta firma empleado',
+            'signature_employer_label'    => 'Etiqueta firma empleador',
+            'signature_employer_sublabel' => 'Subetiqueta firma empleador',
+            'show_header'                 => 'Mostrar encabezado',
+            'show_footer'                 => 'Mostrar pie de página',
+        ];
+
+        $html = '<ul class="space-y-0.5 text-sm">';
+        foreach ($values as $key => $value) {
+            $label     = $fieldLabels[$key] ?? Str::headline($key);
+            $formatted = $this->formatAuditValue($key, $value);
+            $html .= "<li><span class=\"text-gray-500\">{$label}:</span> <span class=\"font-medium\">{$formatted}</span></li>";
+        }
+        $html .= '</ul>';
+
+        return new HtmlString($html);
+    }
+
+    /**
+     * Convierte el valor crudo de un campo auditado a su representación legible.
+     */
+    private function formatAuditValue(string $key, mixed $value): string
+    {
+        if ($value === null || $value === '') {
+            return '—';
+        }
+
+        return match ($key) {
+            'show_header', 'show_footer' => $value ? 'Sí' : 'No',
+            'intro_text', 'body', 'closing_text', 'signature_notes' => '(texto HTML — ver plantilla)',
+            default => (string) $value,
+        };
     }
 }


### PR DESCRIPTION
## Resumen

- **Fix:** import faltante de `Notification` en `ListContractTemplates`
- **CI:** actualizar `actions/checkout` a v4.2.2 para compatibilidad con Node.js 24
- **Contratos:** eliminar sección "Notas" del form e infolist; "Cláusulas Adicionales" siempre expandida por defecto
- **Plantillas — Vista Previa:** botón "Vista Previa PDF" directo desde el listado (sin entrar a editar)
- **Plantillas — Restaurar:** botón "Restaurar valores base" en la pantalla de edición — resetea las 4 secciones de texto con confirmación
- **Plantillas — Copiar:** acción "Copiar a empresa" para duplicar una plantilla a otra empresa activa, con aviso si ya existe una del mismo tipo
- **Plantillas — Badges:** columna "Secciones" muestra 4 badges individuales (verde = configurada, naranja = vacía) en lugar de un texto plano
- **Plantillas — Auditoría:** modelo implementa `Auditable`, nueva página `ViewRecord` con `RelationManager` de historial de cambios

## Plan de pruebas

- [ ] Abrir listado de Plantillas → verificar badges por sección (verde/naranja)
- [ ] Click en "Vista Previa" desde el listado → PDF abre en nueva pestaña
- [ ] Editar una plantilla → "Restaurar valores base" → confirmar → textos se resetean y el form se recarga
- [ ] Editar una plantilla → "Copiar a empresa" → seleccionar empresa destino → verificar aviso si ya existe
- [ ] Guardar cambios en una plantilla → redirige a vista de detalle → historial muestra la modificación con usuario y fecha
- [ ] Verificar que el warning de Node.js 20 desaparece en el próximo deploy

https://claude.ai/code/session_01DkPqvi3dsrDQW1snBbf1mP

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkPqvi3dsrDQW1snBbf1mP)_