### PR TITLE
feat: add {sucursal}, {fecha_nacimiento_empleado}, {telefono_empleado} to contract templates

### DIFF
--- a/app/Http/Controllers/ContractController.php
+++ b/app/Http/Controllers/ContractController.php
@@ -267,6 +267,9 @@ class ContractController extends Controller
             },
             '{tipo_salario}' => $contract->salary_type ? Contract::getSalaryTypeLabel($contract->salary_type) : '...................',
             '{departamento}' => $contract->department?->name ?? $contract->position?->department?->name ?? '...................',
+            '{sucursal}' => $employee?->branch?->name ?? '...................',
+            '{fecha_nacimiento_empleado}' => $employee?->birth_date?->format('d/m/Y') ?? '...................',
+            '{telefono_empleado}' => $employee?->phone ?? '...................',
         ];
     }
 
@@ -310,6 +313,9 @@ class ContractController extends Controller
             '{metodo_pago}' => 'Débito bancario',
             '{tipo_salario}' => 'Mensualizado (Sueldo)',
             '{departamento}' => 'Administración',
+            '{sucursal}' => 'Sucursal Central',
+            '{fecha_nacimiento_empleado}' => '15/03/1995',
+            '{telefono_empleado}' => '0981123456',
         ];
     }
 

--- a/app/Models/ContractTemplate.php
+++ b/app/Models/ContractTemplate.php
@@ -117,6 +117,9 @@ class ContractTemplate extends Model implements Auditable
             '{metodo_pago}' => 'Método de pago (Efectivo / Débito bancario / Cheque)',
             '{tipo_salario}' => 'Tipo de remuneración (Mensualizado / Jornalero)',
             '{departamento}' => 'Nombre del departamento del cargo',
+            '{sucursal}' => 'Nombre de la sucursal del empleado',
+            '{fecha_nacimiento_empleado}' => 'Fecha de nacimiento del empleado (dd/mm/YYYY)',
+            '{telefono_empleado}' => 'Teléfono de contacto del empleado',
         ];
     }
 


### PR DESCRIPTION
## Summary

- Agrega 3 nuevas variables a las plantillas de contratos:
  - `{sucursal}` — nombre de la sucursal del empleado
  - `{fecha_nacimiento_empleado}` — fecha de nacimiento (dd/mm/YYYY)
  - `{telefono_empleado}` — teléfono de contacto del empleado
- Las 3 variables están disponibles en el catálogo visible al editar plantillas (`getAvailableVariables()`)
- Se resuelven correctamente en PDFs reales (`buildVarsMap()`) y en la vista previa de plantilla (`buildSampleVarsMap()`)

## Test plan

- [ ] Abrir una plantilla de contrato en edición — verificar que `{sucursal}`, `{fecha_nacimiento_empleado}` y `{telefono_empleado}` aparecen en el listado de variables disponibles
- [ ] Usar `{sucursal}` en el cuerpo de una plantilla, generar la vista previa PDF — debe mostrar "Sucursal Central"
- [ ] Generar el PDF de un contrato real — las 3 variables deben resolverse con los datos del empleado

https://claude.ai/code/session_01TjN5CnNxDnRXevGKxDvYVu

---
_Generated by [Claude Code](https://claude.ai/code/session_01TjN5CnNxDnRXevGKxDvYVu)_