### PR TITLE
feat: add schedule variables to contract templates

### DIFF
--- a/app/Http/Controllers/ContractController.php
+++ b/app/Http/Controllers/ContractController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Contract;
 use App\Models\ContractTemplate;
+use App\Models\ScheduleDay;
 use Barryvdh\DomPDF\Facade\Pdf;
 use Carbon\Carbon;
 
@@ -45,6 +46,22 @@ class ContractController extends Controller
             : app(\App\Settings\PayrollSettings::class)->daily_hours * 6;
         $weeklyHoursInWords = self::numberToWords($weeklyHours);
 
+        $startTime = $weekdayDay?->start_time
+            ? Carbon::parse($weekdayDay->start_time)->format('H:i')
+            : null;
+        $endTime = $weekdayDay?->end_time
+            ? Carbon::parse($weekdayDay->end_time)->format('H:i')
+            : null;
+        $dailyHours = $weekdayDay ? (int) $weekdayDay->scheduled_hours : null;
+        $activeDayNums = $scheduleDays->where('is_active', true)->sortBy('day_of_week')->pluck('day_of_week');
+        $dayNames = ScheduleDay::getDayOptions();
+        $diasLaborales = $activeDayNums->isNotEmpty()
+            ? ($activeDayNums->count() === 1
+                ? ($dayNames[$activeDayNums->first()] ?? null)
+                : ($dayNames[$activeDayNums->first()] ?? '').' a '.($dayNames[$activeDayNums->last()] ?? ''))
+            : null;
+        $tiempoDescanso = self::formatBreakTime($breakMinutes);
+
         $employeeAge = $contract->employee?->birth_date
             ? $contract->employee->birth_date->age
             : null;
@@ -82,6 +99,11 @@ class ContractController extends Controller
             durationDescription: $durationDescription,
             employeeAge: $employeeAge,
             formattedAddress: $formattedAddress,
+            startTime: $startTime,
+            endTime: $endTime,
+            dailyHours: $dailyHours,
+            diasLaborales: $diasLaborales,
+            tiempoDescanso: $tiempoDescanso,
         );
 
         // Resolver secciones de la plantilla (si existe), con scope por empresa
@@ -228,6 +250,11 @@ class ContractController extends Controller
         string $durationDescription,
         ?int $employeeAge,
         ?string $formattedAddress = null,
+        ?string $startTime = null,
+        ?string $endTime = null,
+        ?int $dailyHours = null,
+        ?string $diasLaborales = null,
+        ?string $tiempoDescanso = null,
     ): array {
         return [
             '{ciudad}' => $company?->city ?? '.............................',
@@ -270,6 +297,11 @@ class ContractController extends Controller
             '{sucursal}' => $employee?->branch?->name ?? '...................',
             '{fecha_nacimiento_empleado}' => $employee?->birth_date?->format('d/m/Y') ?? '...................',
             '{telefono_empleado}' => $employee?->phone ?? '...................',
+            '{hora_entrada}' => $startTime ?? '...................',
+            '{hora_salida}' => $endTime ?? '...................',
+            '{horas_diarias}' => $dailyHours !== null ? (string) $dailyHours : '...................',
+            '{dias_laborales}' => $diasLaborales ?? '...................',
+            '{tiempo_descanso}' => $tiempoDescanso ?? '...................',
         ];
     }
 
@@ -316,7 +348,37 @@ class ContractController extends Controller
             '{sucursal}' => 'Sucursal Central',
             '{fecha_nacimiento_empleado}' => '15/03/1995',
             '{telefono_empleado}' => '0981123456',
+            '{hora_entrada}' => '07:00',
+            '{hora_salida}' => '16:00',
+            '{horas_diarias}' => '8',
+            '{dias_laborales}' => 'Lunes a Viernes',
+            '{tiempo_descanso}' => '1 hora',
         ];
+    }
+
+    /**
+     * Formatea los minutos de descanso como texto legible (ej: "1 hora", "30 minutos", "1 hora y 30 minutos").
+     */
+    private static function formatBreakTime(int $minutes): string
+    {
+        if ($minutes === 0) {
+            return 'Sin descanso';
+        }
+
+        $hours = intdiv($minutes, 60);
+        $remaining = $minutes % 60;
+
+        $parts = [];
+
+        if ($hours > 0) {
+            $parts[] = $hours === 1 ? '1 hora' : "{$hours} horas";
+        }
+
+        if ($remaining > 0) {
+            $parts[] = "{$remaining} minutos";
+        }
+
+        return implode(' y ', $parts);
     }
 
     /**

--- a/app/Models/ContractTemplate.php
+++ b/app/Models/ContractTemplate.php
@@ -120,6 +120,11 @@ class ContractTemplate extends Model implements Auditable
             '{sucursal}' => 'Nombre de la sucursal del empleado',
             '{fecha_nacimiento_empleado}' => 'Fecha de nacimiento del empleado (dd/mm/YYYY)',
             '{telefono_empleado}' => 'Teléfono de contacto del empleado',
+            '{hora_entrada}' => 'Hora de entrada al trabajo (ej: 07:00)',
+            '{hora_salida}' => 'Hora de salida del trabajo (ej: 16:00)',
+            '{horas_diarias}' => 'Horas de trabajo por día (número)',
+            '{dias_laborales}' => 'Días laborales (ej: Lunes a Viernes)',
+            '{tiempo_descanso}' => 'Duración del descanso / almuerzo (ej: 1 hora)',
         ];
     }
 


### PR DESCRIPTION
## Summary

- Agrega 5 nuevas variables de horario a las plantillas de contratos:
  - `{hora_entrada}` — hora de entrada estándar (ej: 07:00)
  - `{hora_salida}` — hora de salida estándar (ej: 16:00)
  - `{horas_diarias}` — horas de trabajo por día (número)
  - `{dias_laborales}` — días laborales (ej: Lunes a Viernes / Lunes a Sábado)
  - `{tiempo_descanso}` — duración del descanso/almuerzo (ej: 1 hora / 30 minutos)
- Las variables se resuelven desde el horario vigente del empleado a la fecha de inicio del contrato
- Si el empleado no tiene horario asignado, las variables muestran `................`
- Agrega helper privado `formatBreakTime()` para formatear los minutos de descanso como texto legible

## Test plan

- [ ] Usar `{hora_entrada}` y `{hora_salida}` en una plantilla, generar PDF — deben mostrar los horarios del empleado en formato HH:MM
- [ ] Usar `{dias_laborales}` — verificar que muestra "Lunes a Viernes" para horarios de lunes a viernes, "Lunes a Sábado" si trabaja sábado
- [ ] Usar `{tiempo_descanso}` — verificar que muestra "1 hora" para 60 min de break, "30 minutos" para 30 min, etc.
- [ ] Vista previa de plantilla — las 5 variables deben mostrar valores de muestra

https://claude.ai/code/session_01TjN5CnNxDnRXevGKxDvYVu

---
_Generated by [Claude Code](https://claude.ai/code/session_01TjN5CnNxDnRXevGKxDvYVu)_