### PR TITLE
feat: add break schedule variables to contract templates

### DIFF
--- a/app/Http/Controllers/ContractController.php
+++ b/app/Http/Controllers/ContractController.php
@@ -62,6 +62,17 @@ class ContractController extends Controller
             : null;
         $tiempoDescanso = self::formatBreakTime($breakMinutes);
 
+        $weekdayBreaks = $weekdayDay ? $weekdayDay->breaks->sortBy('start_time') : collect();
+        $horaDescansoInicio = $weekdayBreaks->isNotEmpty()
+            ? Carbon::parse($weekdayBreaks->first()->start_time)->format('H:i')
+            : null;
+        $horaDescansoFin = $weekdayBreaks->isNotEmpty()
+            ? Carbon::parse($weekdayBreaks->last()->end_time)->format('H:i')
+            : null;
+        $horarioDescanso = $weekdayBreaks->isNotEmpty()
+            ? $weekdayBreaks->map(fn ($b) => Carbon::parse($b->start_time)->format('H:i').' a '.Carbon::parse($b->end_time)->format('H:i'))->implode(' y ')
+            : null;
+
         $employeeAge = $contract->employee?->birth_date
             ? $contract->employee->birth_date->age
             : null;
@@ -104,6 +115,9 @@ class ContractController extends Controller
             dailyHours: $dailyHours,
             diasLaborales: $diasLaborales,
             tiempoDescanso: $tiempoDescanso,
+            horaDescansoInicio: $horaDescansoInicio,
+            horaDescansoFin: $horaDescansoFin,
+            horarioDescanso: $horarioDescanso,
         );
 
         // Resolver secciones de la plantilla (si existe), con scope por empresa
@@ -255,6 +269,9 @@ class ContractController extends Controller
         ?int $dailyHours = null,
         ?string $diasLaborales = null,
         ?string $tiempoDescanso = null,
+        ?string $horaDescansoInicio = null,
+        ?string $horaDescansoFin = null,
+        ?string $horarioDescanso = null,
     ): array {
         return [
             '{ciudad}' => $company?->city ?? '.............................',
@@ -302,6 +319,9 @@ class ContractController extends Controller
             '{horas_diarias}' => $dailyHours !== null ? (string) $dailyHours : '...................',
             '{dias_laborales}' => $diasLaborales ?? '...................',
             '{tiempo_descanso}' => $tiempoDescanso ?? '...................',
+            '{hora_descanso_inicio}' => $horaDescansoInicio ?? '...................',
+            '{hora_descanso_fin}' => $horaDescansoFin ?? '...................',
+            '{horario_descanso}' => $horarioDescanso ?? '...................',
         ];
     }
 
@@ -353,6 +373,9 @@ class ContractController extends Controller
             '{horas_diarias}' => '8',
             '{dias_laborales}' => 'Lunes a Viernes',
             '{tiempo_descanso}' => '1 hora',
+            '{hora_descanso_inicio}' => '12:00',
+            '{hora_descanso_fin}' => '13:00',
+            '{horario_descanso}' => '12:00 a 13:00',
         ];
     }
 

--- a/app/Models/ContractTemplate.php
+++ b/app/Models/ContractTemplate.php
@@ -125,6 +125,9 @@ class ContractTemplate extends Model implements Auditable
             '{horas_diarias}' => 'Horas de trabajo por día (número)',
             '{dias_laborales}' => 'Días laborales (ej: Lunes a Viernes)',
             '{tiempo_descanso}' => 'Duración del descanso / almuerzo (ej: 1 hora)',
+            '{hora_descanso_inicio}' => 'Hora de inicio del primer descanso (ej: 12:00)',
+            '{hora_descanso_fin}' => 'Hora de fin del último descanso (ej: 13:00)',
+            '{horario_descanso}' => 'Horario completo de descanso (ej: 12:00 a 13:00 y 16:00 a 16:15)',
         ];
     }
 


### PR DESCRIPTION
## Summary

- Agrega 3 nuevas variables de descanso al sistema de plantillas de contrato:
  - `{hora_descanso_inicio}` — hora de inicio del primer descanso del día laboral estándar (ej: 12:00)
  - `{hora_descanso_fin}` — hora de fin del último descanso (ej: 13:00)
  - `{horario_descanso}` — todos los descansos listados (ej: "12:00 a 13:00" o "12:00 a 13:00 y 16:00 a 16:15")
- Se usan los descansos del día laboral estándar (Lunes–Viernes), consistente con `{hora_entrada}` y `{hora_salida}`
- Si hay múltiples descansos en el día, `{horario_descanso}` los lista separados por " y "
- Si el empleado no tiene horario o no tiene descansos configurados, las variables muestran `................`

## Test plan

- [ ] Configurar un descanso de almuerzo (12:00–13:00) en el horario del empleado y verificar que `{horario_descanso}` muestra "12:00 a 13:00"
- [ ] Agregar un segundo descanso (16:00–16:15) y verificar que `{horario_descanso}` muestra "12:00 a 13:00 y 16:00 a 16:15"
- [ ] Vista previa de plantilla muestra los valores de muestra correctos

https://claude.ai/code/session_01TjN5CnNxDnRXevGKxDvYVu

---
_Generated by [Claude Code](https://claude.ai/code/session_01TjN5CnNxDnRXevGKxDvYVu)_