### PR TITLE
feat: improve Filament dashboard with new widgets and reordering

### DIFF
--- a/app/Filament/Pages/Dashboard.php
+++ b/app/Filament/Pages/Dashboard.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Filament\Pages;
+
+/** Dashboard personalizado con grid de 4 columnas para soporte de widgets half-width a futuro. */
+class Dashboard extends \Filament\Pages\Dashboard
+{
+    /**
+     * Usa 4 columnas para que en el futuro se puedan colocar widgets de 2 cols lado a lado.
+     * Los widgets con $columnSpan = 'full' ocupan las 4 columnas (ancho completo).
+     */
+    public function getColumns(): int|string|array
+    {
+        return 4;
+    }
+}

--- a/app/Filament/Widgets/AguinaldoStatusWidget.php
+++ b/app/Filament/Widgets/AguinaldoStatusWidget.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Filament\Resources\AguinaldoPeriodResource;
+use App\Models\AguinaldoPeriod;
+use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+
+/** Widget condicional de aguinaldo: visible solo cuando hay un período en draft o processing. */
+class AguinaldoStatusWidget extends BaseWidget
+{
+    protected static ?int $sort = 7;
+
+    protected static ?string $pollingInterval = '60s';
+
+    /**
+     * Mapeo de estados a etiquetas en español.
+     *
+     * @var array<string, string>
+     */
+    private const STATUS_LABELS = [
+        'draft' => 'Borrador',
+        'processing' => 'En procesamiento',
+        'closed' => 'Cerrado',
+    ];
+
+    /** Solo visible cuando hay un período de aguinaldo activo (no cerrado). */
+    public static function canView(): bool
+    {
+        return AguinaldoPeriod::whereIn('status', ['draft', 'processing'])->exists();
+    }
+
+    /**
+     * Retorna las tarjetas del estado del período de aguinaldo activo.
+     *
+     * @return array<int, Stat>
+     */
+    protected function getStats(): array
+    {
+        $period = AguinaldoPeriod::whereIn('status', ['draft', 'processing'])
+            ->latest('year')
+            ->first();
+
+        if (! $period) {
+            return [];
+        }
+
+        // Agrega counts y monto en una sola query
+        $stats = $period->aguinaldos()
+            ->selectRaw("
+                COUNT(*) as total,
+                SUM(CASE WHEN status = 'pending' THEN 1 ELSE 0 END) as pending,
+                SUM(amount) as total_amount
+            ")
+            ->first();
+
+        $total = (int) ($stats->total ?? 0);
+        $pending = (int) ($stats->pending ?? 0);
+        $totalAmount = (float) ($stats->total_amount ?? 0);
+
+        $statusLabel = self::STATUS_LABELS[$period->status] ?? $period->status;
+        $periodColor = $period->status === 'processing' ? 'primary' : 'gray';
+        $periodUrl = AguinaldoPeriodResource::getUrl('view', ['record' => $period->id]);
+
+        return [
+            Stat::make('Período de Aguinaldo', (string) $period->year)
+                ->description('Estado: '.$statusLabel)
+                ->descriptionIcon('heroicon-o-calendar')
+                ->color($periodColor)
+                ->icon('heroicon-o-gift')
+                ->url($periodUrl),
+
+            Stat::make('Aguinaldos Generados', $total)
+                ->description('Empleados incluidos en el período')
+                ->descriptionIcon('heroicon-o-user-group')
+                ->color('gray')
+                ->icon('heroicon-o-users')
+                ->url($periodUrl),
+
+            Stat::make('Pendientes de Pago', $pending)
+                ->description($pending === 0
+                    ? 'Todos los aguinaldos pagados'
+                    : ($pending === 1 ? '1 aguinaldo por pagar' : "{$pending} aguinaldos por pagar"))
+                ->descriptionIcon($pending > 0 ? 'heroicon-o-clock' : 'heroicon-o-check-circle')
+                ->color($pending > 0 ? 'warning' : 'success')
+                ->icon('heroicon-o-clipboard-document-check')
+                ->url($periodUrl),
+
+            Stat::make('Total a Pagar', 'Gs. '.number_format($totalAmount, 0, ',', '.'))
+                ->description('Monto total de aguinaldos pendientes')
+                ->descriptionIcon('heroicon-o-banknotes')
+                ->color('info')
+                ->icon('heroicon-o-currency-dollar')
+                ->url($periodUrl),
+        ];
+    }
+}

--- a/app/Filament/Widgets/BranchAttendanceToday.php
+++ b/app/Filament/Widgets/BranchAttendanceToday.php
@@ -10,9 +10,12 @@ use Filament\Widgets\ChartWidget;
 class BranchAttendanceToday extends ChartWidget
 {
     protected static ?string $heading = 'Presencias / Ausencias por Sucursal';
+
     protected static ?string $description = 'Estado de asistencia del día de hoy';
-    protected int | string | array $columnSpan = 'full';
-    protected static ?int $sort = 2;
+
+    protected int|string|array $columnSpan = 'full';
+
+    protected static ?int $sort = 4;
 
     /** Refresca el gráfico cada 60 segundos. */
     protected static ?string $pollingInterval = '60s';
@@ -27,7 +30,7 @@ class BranchAttendanceToday extends ChartWidget
     {
         $today = now()->toDateString();
 
-        $branches = Branch::withCount(['employees' => fn($q) => $q->where('status', 'active')])
+        $branches = Branch::withCount(['employees' => fn ($q) => $q->where('status', 'active')])
             ->having('employees_count', '>', 0)
             ->get();
 
@@ -39,39 +42,39 @@ class BranchAttendanceToday extends ChartWidget
             ->selectRaw('employees.branch_id, COUNT(*) as count')
             ->groupBy('employees.branch_id')
             ->pluck('count', 'branch_id')
-            ->map(fn($c) => (int) $c);
+            ->map(fn ($c) => (int) $c);
 
-        $labels    = [];
+        $labels = [];
         $presentes = [];
-        $ausentes  = [];
+        $ausentes = [];
 
         foreach ($branches as $branch) {
-            $total     = $branch->employees_count;
+            $total = $branch->employees_count;
             $presentes_branch = $presentesPorSucursal->get($branch->id, 0);
 
-            $labels[]    = $branch->name . " ({$total})";
+            $labels[] = $branch->name." ({$total})";
             $presentes[] = $presentes_branch;
-            $ausentes[]  = max(0, $total - $presentes_branch);
+            $ausentes[] = max(0, $total - $presentes_branch);
         }
 
         return [
             'datasets' => [
                 [
-                    'label'            => 'Presentes',
-                    'data'             => $presentes,
-                    'backgroundColor'  => '#10b981',
-                    'borderColor'      => '#059669',
-                    'borderWidth'      => 1,
-                    'barPercentage'    => 0.6,
+                    'label' => 'Presentes',
+                    'data' => $presentes,
+                    'backgroundColor' => '#10b981',
+                    'borderColor' => '#059669',
+                    'borderWidth' => 1,
+                    'barPercentage' => 0.6,
                     'categoryPercentage' => 0.8,
                 ],
                 [
-                    'label'            => 'Ausentes',
-                    'data'             => $ausentes,
-                    'backgroundColor'  => '#ef4444',
-                    'borderColor'      => '#dc2626',
-                    'borderWidth'      => 1,
-                    'barPercentage'    => 0.6,
+                    'label' => 'Ausentes',
+                    'data' => $ausentes,
+                    'backgroundColor' => '#ef4444',
+                    'borderColor' => '#dc2626',
+                    'borderWidth' => 1,
+                    'barPercentage' => 0.6,
                     'categoryPercentage' => 0.8,
                 ],
             ],
@@ -79,9 +82,6 @@ class BranchAttendanceToday extends ChartWidget
         ];
     }
 
-    /**
-     * @return string
-     */
     protected function getType(): string
     {
         return 'bar';
@@ -95,29 +95,29 @@ class BranchAttendanceToday extends ChartWidget
         return [
             'plugins' => [
                 'legend' => [
-                    'display'  => true,
+                    'display' => true,
                     'position' => 'top',
                 ],
                 'tooltip' => [
-                    'enabled'   => true,
-                    'mode'      => 'index',
+                    'enabled' => true,
+                    'mode' => 'index',
                     'intersect' => false,
                 ],
             ],
             'indexAxis' => 'y',
             'scales' => [
                 'x' => [
-                    'stacked'     => false,
+                    'stacked' => false,
                     'beginAtZero' => true,
-                    'ticks'       => ['stepSize' => 1, 'precision' => 0],
-                    'grid'        => ['display' => true, 'drawBorder' => false],
+                    'ticks' => ['stepSize' => 1, 'precision' => 0],
+                    'grid' => ['display' => true, 'drawBorder' => false],
                 ],
                 'y' => [
                     'stacked' => false,
-                    'grid'    => ['display' => false],
+                    'grid' => ['display' => false],
                 ],
             ],
-            'responsive'          => true,
+            'responsive' => true,
             'maintainAspectRatio' => false,
         ];
     }

--- a/app/Filament/Widgets/ExpiringContracts.php
+++ b/app/Filament/Widgets/ExpiringContracts.php
@@ -4,22 +4,20 @@ namespace App\Filament\Widgets;
 
 use App\Models\Contract;
 use App\Settings\GeneralSettings;
-use Filament\Tables\Table;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
 use Filament\Widgets\TableWidget as BaseWidget;
 use Illuminate\Database\Eloquent\Builder;
 
 /** Widget de tabla: contratos activos próximos a vencer o ya vencidos. Solo visible cuando existen. */
 class ExpiringContracts extends BaseWidget
 {
-    protected static ?int $sort = 4;
+    protected static ?int $sort = 6;
+
     protected static ?string $heading = 'Contratos por Vencer';
+
     protected int|string|array $columnSpan = 'full';
 
-    /**
-     * @param  Table $table
-     * @return Table
-     */
     public function table(Table $table): Table
     {
         $settings = app(GeneralSettings::class);
@@ -50,15 +48,15 @@ class ExpiringContracts extends BaseWidget
                     ->searchable(query: fn (Builder $query, string $search) => $query->whereHas(
                         'employee',
                         fn ($q) => $q->where('first_name', 'like', "%{$search}%")
-                                     ->orWhere('last_name', 'like', "%{$search}%")
+                            ->orWhere('last_name', 'like', "%{$search}%")
                     ))
                     ->wrap(),
 
                 TextColumn::make('type')
                     ->label('Tipo')
                     ->badge()
-                    ->formatStateUsing(fn(string $state) => Contract::getTypeLabel($state))
-                    ->color(fn(string $state): string => Contract::getTypeColor($state)),
+                    ->formatStateUsing(fn (string $state) => Contract::getTypeLabel($state))
+                    ->color(fn (string $state): string => Contract::getTypeColor($state)),
 
                 TextColumn::make('position.name')
                     ->label('Cargo')
@@ -67,8 +65,8 @@ class ExpiringContracts extends BaseWidget
                 TextColumn::make('end_date')
                     ->label('Vence')
                     ->date('d/m/Y')
-                    ->description(fn(Contract $record) => $record->expiration_description)
-                    ->color(fn(Contract $record) => $record->isExpired() ? 'danger' : 'warning'),
+                    ->description(fn (Contract $record) => $record->expiration_description)
+                    ->color(fn (Contract $record) => $record->isExpired() ? 'danger' : 'warning'),
 
                 TextColumn::make('salary')
                     ->label('Salario')
@@ -83,8 +81,6 @@ class ExpiringContracts extends BaseWidget
 
     /**
      * Solo muestra el widget cuando hay contratos por vencer o ya vencidos.
-     *
-     * @return bool
      */
     public static function canView(): bool
     {

--- a/app/Filament/Widgets/LatestAttendances.php
+++ b/app/Filament/Widgets/LatestAttendances.php
@@ -18,19 +18,19 @@ use pxlrbt\FilamentExcel\Exports\ExcelExport;
 /** Widget de tabla: últimas marcaciones del día actual. */
 class LatestAttendances extends BaseWidget
 {
-    protected int | string | array $columnSpan = 'full';
+    protected int|string|array $columnSpan = 'full';
+
     protected static ?string $heading = 'Últimas Marcaciones de Hoy';
+
     protected static ?string $description = 'Marcaciones del día actual en tiempo real';
-    protected static ?int $sort = 3;
+
+    protected static ?int $sort = 5;
 
     /** Refresca la tabla cada 30 segundos para reflejar marcaciones nuevas. */
     protected static ?string $pollingInterval = '30s';
 
     /**
      * Configura la tabla con columnas, filtros y acciones.
-     *
-     * @param  Table $table
-     * @return Table
      */
     public function table(Table $table): Table
     {
@@ -45,31 +45,31 @@ class LatestAttendances extends BaseWidget
                 TextColumn::make('recorded_at')
                     ->label('Fecha y Hora')
                     ->dateTime('d/m/Y H:i:s')
-                    ->description(fn($record) => $record->recorded_at->diffForHumans())
+                    ->description(fn ($record) => $record->recorded_at->diffForHumans())
                     ->icon('heroicon-o-clock')
                     ->sortable()
                     ->searchable(),
 
                 TextColumn::make('event_type')
                     ->label('Tipo de Evento')
-                    ->formatStateUsing(fn($state) => AttendanceEvent::getEventTypeLabel($state))
+                    ->formatStateUsing(fn ($state) => AttendanceEvent::getEventTypeLabel($state))
                     ->badge()
-                    ->color(fn($state) => AttendanceEvent::getEventTypeColor($state))
-                    ->icon(fn($state) => AttendanceEvent::getEventTypeIcon($state))
+                    ->color(fn ($state) => AttendanceEvent::getEventTypeColor($state))
+                    ->icon(fn ($state) => AttendanceEvent::getEventTypeIcon($state))
                     ->sortable()
                     ->searchable(),
 
                 TextColumn::make('source')
                     ->label('Canal')
-                    ->formatStateUsing(fn($state) => AttendanceEvent::getSourceLabel($state ?? 'manual'))
+                    ->formatStateUsing(fn ($state) => AttendanceEvent::getSourceLabel($state ?? 'manual'))
                     ->badge()
-                    ->color(fn($state) => AttendanceEvent::getSourceColor($state ?? 'manual'))
-                    ->icon(fn($state) => AttendanceEvent::getSourceIcon($state ?? 'manual'))
+                    ->color(fn ($state) => AttendanceEvent::getSourceColor($state ?? 'manual'))
+                    ->icon(fn ($state) => AttendanceEvent::getSourceIcon($state ?? 'manual'))
                     ->toggleable(),
 
                 TextColumn::make('employee_name')
                     ->label('Empleado')
-                    ->description(fn($record) => $record->employee_ci ? 'CI: ' . $record->employee_ci : '')
+                    ->description(fn ($record) => $record->employee_ci ? 'CI: '.$record->employee_ci : '')
                     ->sortable()
                     ->searchable()
                     ->weight('medium')
@@ -92,8 +92,7 @@ class LatestAttendances extends BaseWidget
                     ->placeholder('Todos los empleados')
                     ->relationship('employee', 'first_name')
                     ->getOptionLabelFromRecordUsing(
-                        fn($record) =>
-                        $record->first_name . ' ' . $record->last_name . ' (CI: ' . $record->ci . ')'
+                        fn ($record) => $record->first_name.' '.$record->last_name.' (CI: '.$record->ci.')'
                     )
                     ->searchable()
                     ->preload(false)
@@ -137,21 +136,21 @@ class LatestAttendances extends BaseWidget
 
                             TextEntry::make('event_type')
                                 ->label('Tipo de evento')
-                                ->formatStateUsing(fn($state) => AttendanceEvent::getEventTypeLabel($state))
+                                ->formatStateUsing(fn ($state) => AttendanceEvent::getEventTypeLabel($state))
                                 ->badge()
-                                ->color(fn($state) => AttendanceEvent::getEventTypeColor($state))
-                                ->icon(fn($state) => AttendanceEvent::getEventTypeIcon($state)),
+                                ->color(fn ($state) => AttendanceEvent::getEventTypeColor($state))
+                                ->icon(fn ($state) => AttendanceEvent::getEventTypeIcon($state)),
 
                             TextEntry::make('source')
                                 ->label('Canal')
                                 ->badge()
-                                ->formatStateUsing(fn($state) => AttendanceEvent::getSourceLabel($state ?? 'manual'))
-                                ->color(fn($state) => AttendanceEvent::getSourceColor($state ?? 'manual'))
-                                ->icon(fn($state) => AttendanceEvent::getSourceIcon($state ?? 'manual')),
+                                ->formatStateUsing(fn ($state) => AttendanceEvent::getSourceLabel($state ?? 'manual'))
+                                ->color(fn ($state) => AttendanceEvent::getSourceColor($state ?? 'manual'))
+                                ->icon(fn ($state) => AttendanceEvent::getSourceIcon($state ?? 'manual')),
 
                             TextEntry::make('recorded_at')
                                 ->label('Fecha y hora')
-                                ->formatStateUsing(fn($state) => $state->format('d/m/Y H:i:s') . ' — ' . $state->diffForHumans()),
+                                ->formatStateUsing(fn ($state) => $state->format('d/m/Y H:i:s').' — '.$state->diffForHumans()),
 
                             TextEntry::make('branch_name')
                                 ->label('Sucursal')
@@ -162,7 +161,7 @@ class LatestAttendances extends BaseWidget
                         ViewEntry::make('location_map')
                             ->label('Ubicación en mapa')
                             ->view('filament.resources.attendance-event.location-map')
-                            ->visible(fn(AttendanceEvent $record) => $record->hasValidLocation())
+                            ->visible(fn (AttendanceEvent $record) => $record->hasValidLocation())
                             ->columnSpanFull(),
                     ]),
             ])
@@ -173,7 +172,7 @@ class LatestAttendances extends BaseWidget
                             ExcelExport::make()
                                 ->fromTable()
                                 ->except(['created_at', 'updated_at'])
-                                ->withFilename('marcaciones_hoy_' . now()->format('d_m_Y_H_i_s')),
+                                ->withFilename('marcaciones_hoy_'.now()->format('d_m_Y_H_i_s')),
                         ])
                         ->label('Exportar seleccionados')
                         ->color('success')

--- a/app/Filament/Widgets/PayrollStatusWidget.php
+++ b/app/Filament/Widgets/PayrollStatusWidget.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Filament\Resources\PayrollPeriodResource;
+use App\Models\Payroll;
+use App\Models\PayrollPeriod;
+use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+
+/** Widget de estado de nómina: muestra el período activo y el progreso de aprobación. */
+class PayrollStatusWidget extends BaseWidget
+{
+    protected static ?int $sort = 3;
+
+    protected static ?string $pollingInterval = '60s';
+
+    /**
+     * Mapeo de estados a etiquetas en español.
+     *
+     * @var array<string, string>
+     */
+    private const STATUS_LABELS = [
+        'draft' => 'Borrador',
+        'processing' => 'En procesamiento',
+        'closed' => 'Cerrado',
+    ];
+
+    /**
+     * Retorna las tarjetas del estado de nómina del período activo.
+     *
+     * @return array<int, Stat>
+     */
+    protected function getStats(): array
+    {
+        // Prioriza períodos activos; cae al último cerrado si no hay ninguno
+        $period = PayrollPeriod::whereIn('status', ['draft', 'processing'])
+            ->latest('start_date')
+            ->first()
+            ?? PayrollPeriod::where('status', 'closed')
+                ->latest('start_date')
+                ->first();
+
+        if (! $period) {
+            return [
+                Stat::make('Período de Nómina', '—')
+                    ->description('No hay períodos registrados')
+                    ->descriptionIcon('heroicon-o-information-circle')
+                    ->color('gray')
+                    ->icon('heroicon-o-calendar'),
+            ];
+        }
+
+        // Agrega counts y suma en una sola query
+        $payrollStats = Payroll::where('payroll_period_id', $period->id)
+            ->selectRaw("
+                COUNT(*) as total,
+                SUM(CASE WHEN status IN ('draft', 'approved') THEN 1 ELSE 0 END) as pending,
+                SUM(CASE WHEN status = 'approved' THEN net_salary ELSE 0 END) as total_to_pay
+            ")
+            ->first();
+
+        $totalPayrolls = (int) ($payrollStats->total ?? 0);
+        $pendingCount = (int) ($payrollStats->pending ?? 0);
+        $totalToPay = (float) ($payrollStats->total_to_pay ?? 0);
+
+        $periodColor = match ($period->status) {
+            'processing' => 'primary',
+            'closed' => 'success',
+            default => 'gray',
+        };
+
+        $statusLabel = self::STATUS_LABELS[$period->status] ?? $period->status;
+        $periodUrl = PayrollPeriodResource::getUrl('view', ['record' => $period->id]);
+
+        return [
+            Stat::make('Período de Nómina', $period->name)
+                ->description('Estado: '.$statusLabel)
+                ->descriptionIcon('heroicon-o-calendar')
+                ->color($periodColor)
+                ->icon('heroicon-o-document-text')
+                ->url($periodUrl),
+
+            Stat::make('Nóminas Generadas', $totalPayrolls)
+                ->description('Recibos en '.$period->name)
+                ->descriptionIcon('heroicon-o-user-group')
+                ->color('gray')
+                ->icon('heroicon-o-users')
+                ->url($periodUrl),
+
+            Stat::make('Por Aprobar / Pagar', $pendingCount)
+                ->description($pendingCount === 0
+                    ? 'Todas las nóminas al día'
+                    : ($pendingCount === 1 ? '1 nómina pendiente de acción' : "{$pendingCount} nóminas pendientes de acción"))
+                ->descriptionIcon($pendingCount > 0 ? 'heroicon-o-clock' : 'heroicon-o-check-circle')
+                ->color($pendingCount > 0 ? 'danger' : 'success')
+                ->icon('heroicon-o-clipboard-document-check')
+                ->url($periodUrl),
+
+            Stat::make('Total Neto a Pagar', 'Gs. '.number_format($totalToPay, 0, ',', '.'))
+                ->description('Suma de nóminas aprobadas')
+                ->descriptionIcon('heroicon-o-banknotes')
+                ->color('info')
+                ->icon('heroicon-o-currency-dollar')
+                ->url($periodUrl),
+        ];
+    }
+}

--- a/app/Filament/Widgets/PendingApprovalsWidget.php
+++ b/app/Filament/Widgets/PendingApprovalsWidget.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Filament\Resources\AbsenceResource;
+use App\Filament\Resources\AdvanceResource;
+use App\Filament\Resources\EmployeeLeaveResource;
+use App\Filament\Resources\LoanResource;
+use App\Models\Absence;
+use App\Models\Advance;
+use App\Models\EmployeeLeave;
+use App\Models\Loan;
+use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+
+/** Widget de aprobaciones pendientes: muestra elementos que requieren acción inmediata. */
+class PendingApprovalsWidget extends BaseWidget
+{
+    protected static ?int $sort = 2;
+
+    protected static ?string $pollingInterval = '60s';
+
+    /**
+     * Retorna las tarjetas de pendientes por módulo.
+     *
+     * @return array<int, Stat>
+     */
+    protected function getStats(): array
+    {
+        $loansPending = Loan::where('status', 'pending')->count();
+        $advancesPending = Advance::where('status', 'pending')->count();
+        $absencesPending = Absence::where('status', 'pending')->count();
+        $leavesPending = EmployeeLeave::where('status', 'pending')->count();
+
+        return [
+            Stat::make('Préstamos por Aprobar', $loansPending)
+                ->description($loansPending === 0
+                    ? 'Sin solicitudes pendientes'
+                    : ($loansPending === 1 ? '1 solicitud en espera' : "{$loansPending} solicitudes en espera"))
+                ->descriptionIcon($loansPending > 0 ? 'heroicon-o-exclamation-circle' : 'heroicon-o-check-circle')
+                ->color($loansPending > 0 ? 'warning' : 'success')
+                ->icon('heroicon-o-banknotes')
+                ->url(LoanResource::getUrl('index')),
+
+            Stat::make('Adelantos por Aprobar', $advancesPending)
+                ->description($advancesPending === 0
+                    ? 'Sin adelantos pendientes'
+                    : ($advancesPending === 1 ? '1 adelanto en espera' : "{$advancesPending} adelantos en espera"))
+                ->descriptionIcon($advancesPending > 0 ? 'heroicon-o-exclamation-circle' : 'heroicon-o-check-circle')
+                ->color($advancesPending > 0 ? 'warning' : 'success')
+                ->icon('heroicon-o-wallet')
+                ->url(AdvanceResource::getUrl('index')),
+
+            Stat::make('Ausencias por Revisar', $absencesPending)
+                ->description($absencesPending === 0
+                    ? 'Sin ausencias pendientes'
+                    : ($absencesPending === 1 ? '1 ausencia por clasificar' : "{$absencesPending} ausencias por clasificar"))
+                ->descriptionIcon($absencesPending > 0 ? 'heroicon-o-exclamation-circle' : 'heroicon-o-check-circle')
+                ->color($absencesPending > 0 ? 'danger' : 'success')
+                ->icon('heroicon-o-user-minus')
+                ->url(AbsenceResource::getUrl('index')),
+
+            Stat::make('Licencias por Aprobar', $leavesPending)
+                ->description($leavesPending === 0
+                    ? 'Sin licencias pendientes'
+                    : ($leavesPending === 1 ? '1 licencia por aprobar' : "{$leavesPending} licencias por aprobar"))
+                ->descriptionIcon($leavesPending > 0 ? 'heroicon-o-exclamation-circle' : 'heroicon-o-check-circle')
+                ->color($leavesPending > 0 ? 'warning' : 'success')
+                ->icon('heroicon-o-calendar-days')
+                ->url(EmployeeLeaveResource::getUrl('index')),
+        ];
+    }
+}

--- a/app/Filament/Widgets/StatsOverview.php
+++ b/app/Filament/Widgets/StatsOverview.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Widgets;
 
+use App\Filament\Resources\AbsenceResource;
 use App\Models\AttendanceDay;
 use App\Models\Employee;
 use Carbon\Carbon;
@@ -31,12 +32,12 @@ class StatsOverview extends BaseWidget
             SUM(CASE WHEN status = 'active' THEN 1 ELSE 0 END) as active
         ")->first();
 
-        $totalEmpleados   = (int) $counts->total;
+        $totalEmpleados = (int) $counts->total;
         $empleadosActivos = (int) $counts->active;
 
         $presentesHoy = AttendanceDay::where('date', $today)
             ->where('status', 'present')
-            ->whereHas('employee', fn($q) => $q->where('status', 'active'))
+            ->whereHas('employee', fn ($q) => $q->where('status', 'active'))
             ->count();
 
         // max(0, ...) por si $presentesHoy supera $empleadosActivos (reactivaciones intraday)
@@ -48,14 +49,14 @@ class StatsOverview extends BaseWidget
 
         return [
             Stat::make('Empleados Activos', $empleadosActivos)
-                ->description('Total de ' . $totalEmpleados . ' empleados')
+                ->description('Total de '.$totalEmpleados.' empleados')
                 ->descriptionIcon('heroicon-o-users')
                 ->color('success')
                 ->icon('heroicon-o-check-circle')
                 ->chart($this->getEmployeeTrend()),
 
             Stat::make('Presentes Hoy', $presentesHoy)
-                ->description($porcentajeAsistencia . '% de asistencia')
+                ->description($porcentajeAsistencia.'% de asistencia')
                 ->descriptionIcon('heroicon-o-arrow-trending-up')
                 ->color($porcentajeAsistencia >= 90 ? 'success' : ($porcentajeAsistencia >= 70 ? 'warning' : 'danger'))
                 ->icon('heroicon-o-user-group')
@@ -66,7 +67,8 @@ class StatsOverview extends BaseWidget
                 ->descriptionIcon('heroicon-o-arrow-trending-down')
                 ->color($ausentesHoy === 0 ? 'success' : 'danger')
                 ->icon('heroicon-o-user-minus')
-                ->chart($this->getAbsenceTrend($empleadosActivos)),
+                ->chart($this->getAbsenceTrend($empleadosActivos))
+                ->url(AbsenceResource::getUrl('index')),
 
             Stat::make('Cumpleaños del Mes', $this->getBirthdaysThisMonth())
                 ->description('Celebraciones este mes')
@@ -100,15 +102,15 @@ class StatsOverview extends BaseWidget
             ->selectRaw('DATE(created_at) as date, COUNT(*) as count')
             ->groupBy('date')
             ->pluck('count', 'date')
-            ->map(fn($c) => (int) $c);
+            ->map(fn ($c) => (int) $c);
 
-        $trend      = [];
+        $trend = [];
         $cumulative = $baseCount;
 
         for ($i = 6; $i >= 0; $i--) {
-            $dateStr    = Carbon::today()->subDays($i)->toDateString();
+            $dateStr = Carbon::today()->subDays($i)->toDateString();
             $cumulative += $perDay->get($dateStr, 0);
-            $trend[]    = $cumulative;
+            $trend[] = $cumulative;
         }
 
         return $trend;
@@ -125,17 +127,17 @@ class StatsOverview extends BaseWidget
 
         $presentesPorDia = AttendanceDay::where('date', '>=', $windowStart)
             ->where('status', 'present')
-            ->whereHas('employee', fn($q) => $q->where('status', 'active'))
+            ->whereHas('employee', fn ($q) => $q->where('status', 'active'))
             ->selectRaw('date, COUNT(*) as count')
             ->groupBy('date')
             ->pluck('count', 'date')
-            ->mapWithKeys(fn($count, $date) => [Carbon::parse($date)->toDateString() => (int) $count]);
+            ->mapWithKeys(fn ($count, $date) => [Carbon::parse($date)->toDateString() => (int) $count]);
 
         $trend = [];
         for ($i = 6; $i >= 0; $i--) {
-            $dateStr   = Carbon::today()->subDays($i)->toDateString();
+            $dateStr = Carbon::today()->subDays($i)->toDateString();
             $presentes = $presentesPorDia->get($dateStr, 0);
-            $trend[]   = $empleadosActivos > 0
+            $trend[] = $empleadosActivos > 0
                 ? round(($presentes / $empleadosActivos) * 100)
                 : 0;
         }
@@ -152,13 +154,11 @@ class StatsOverview extends BaseWidget
     {
         $attendanceTrend = $this->getAttendanceTrend($empleadosActivos);
 
-        return array_map(fn(int $pct) => max(0, 100 - $pct), $attendanceTrend);
+        return array_map(fn (int $pct) => max(0, 100 - $pct), $attendanceTrend);
     }
 
     /**
      * Cuenta empleados activos con cumpleaños en el mes actual.
-     *
-     * @return int
      */
     protected function getBirthdaysThisMonth(): int
     {

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -8,7 +8,6 @@ use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
 use Filament\Http\Middleware\DispatchServingFilamentEvent;
 use Filament\Navigation\NavigationGroup;
-use Filament\Pages;
 use Filament\Panel;
 use Filament\PanelProvider;
 use Filament\Support\Colors\Color;
@@ -65,9 +64,7 @@ class AdminPanelProvider extends PanelProvider
             ->plugin(FilamentDocsPlugin::make())
             ->discoverResources(in: app_path('Filament/Resources'), for: 'App\\Filament\\Resources')
             ->discoverPages(in: app_path('Filament/Pages'), for: 'App\\Filament\\Pages')
-            ->pages([
-                Pages\Dashboard::class,
-            ])
+            ->pages([])
             ->discoverWidgets(in: app_path('Filament/Widgets'), for: 'App\\Filament\\Widgets')
             ->middleware([
                 EncryptCookies::class,


### PR DESCRIPTION
- Add PendingApprovalsWidget: 4 stat cards showing pending loans,
  advances, absences, and employee leaves — each links to its module.
- Add PayrollStatusWidget: shows active payroll period name, payrolls
  generated, pending approval count, and total net salary to pay.
- Add AguinaldoStatusWidget: conditional widget (visible only when
  there is a draft/processing aguinaldo period) with 4 stat cards.
- Add custom Dashboard page with 4-column grid layout (prep for future
  half-width widget pairs).
- Update AdminPanelProvider to rely on discoverPages() instead of
  explicit Pages\Dashboard::class now that a custom one exists.
- Reorder existing widgets: BranchAttendanceToday→4, LatestAttendances→5,
  ExpiringContracts→6; new widgets take slots 2 and 3.
- Add URL on StatsOverview's "Ausentes Hoy" card linking to AbsenceResource.

https://claude.ai/code/session_017PuARsVzNCZvCyM5G7rBCs