### PR TITLE
fix: add Content-Type header to deploy webhook curl

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,7 @@ jobs:
           HTTP_STATUS=$(curl -s -o /tmp/deploy_out.json -w "%{http_code}" \
             --max-time 300 \
             -X POST \
+            -H "Content-Type: application/json" \
             -H "X-Deploy-Token: ${{ secrets.DEPLOY_TOKEN }}" \
             https://nominapp.sedacosmetica.com/deploy.php)
 


### PR DESCRIPTION
El deploy del PR #71 falló con HTTP 415 Unsupported Media Type. El proxy openresty rechazó el POST al webhook de deploy porque no tenía `Content-Type`. Agregando el header el proxy lo deja pasar.

**Cambio:** una línea en `.github/workflows/deploy.yml` — agrega `-H "Content-Type: application/json"` al curl.

---
_Generated by [Claude Code](https://claude.ai/code/session_017PuARsVzNCZvCyM5G7rBCs)_