### PR TITLE
fix: send empty JSON body in deploy webhook curl

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,7 @@ jobs:
             -X POST \
             -H "Content-Type: application/json" \
             -H "X-Deploy-Token: ${{ secrets.DEPLOY_TOKEN }}" \
+            -d '{}' \
             https://nominapp.sedacosmetica.com/deploy.php)
 
           # Print the deploy log from the server response


### PR DESCRIPTION
El WAF de openresty rechaza POST con `Content-Type: application/json` pero sin body (mismatch entre el header y el contenido vacío). Enviando `'{}'` como body el WAF lo acepta. El `deploy.php` ignora el body completamente así que no hay impacto en la lógica de deploy.

---
_Generated by [Claude Code](https://claude.ai/code/session_017PuARsVzNCZvCyM5G7rBCs)_