### PR TITLE
Fix employee/company search across all Filament selects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1460,6 +1460,28 @@ Pasar un array de columnas relacionales a `->searchable()` genera SQL inválido:
 
 La causa: Filament usa el nombre de la relación (singular) como alias de tabla en el subquery `EXISTS`, pero MySQL espera el nombre real de la tabla (plural). El `->searchable()` sin array en columnas simples de relación (`->searchable()` sobre `TextColumn::make('employee.ci')`) sí funciona porque Filament genera el subquery correcto en ese caso.
 
+### `->searchable()` en Select con `->relationship()` — respeta el titleAttribute, no el label mostrado
+
+Cuando un `Select::make(...)->relationship($rel, $titleAttribute, ...)` usa `->searchable()` **sin un array explícito de columnas**, Filament busca únicamente contra la columna `$titleAttribute` — no contra lo que `->getOptionLabelFromRecordUsing()` muestra en pantalla. Si el label override incluye más columnas (apellido, CI, trade_name, etc.) que el `$titleAttribute` no cubre, el campo se vuelve efectivamente imposible de buscar por esas columnas — visualmente parece normal, pero escribir texto en el buscador no encuentra nada.
+
+```php
+// ❌ El label muestra nombre + apellido + CI, pero solo busca por 'id'
+Select::make('employee_id')
+    ->relationship('employee', 'id', fn ($query) => $query->where('status', 'active'))
+    ->searchable()
+    ->getOptionLabelFromRecordUsing(fn ($record) => "{$record->first_name} {$record->last_name} — CI: {$record->ci}")
+
+// ✅ El array de searchable() debe cubrir todas las columnas que aparecen en el label
+Select::make('employee_id')
+    ->relationship('employee', 'first_name', fn ($query) => $query->where('status', 'active'))
+    ->searchable(['first_name', 'last_name', 'ci'])
+    ->getOptionLabelFromRecordUsing(fn ($record) => "{$record->first_name} {$record->last_name} — CI: {$record->ci}")
+```
+
+**Caso límite más grave: `titleAttribute` omitido por completo** (`->relationship('perception', modifyQueryUsing: ...)` sin segundo argumento) — sin `searchable([...])` explícito, `getSearchColumns()` retorna `null` y el buscador queda **completamente inerte**: no filtra nada, ni siquiera devuelve cero resultados, simplemente ignora lo que el usuario escribe.
+
+**Regla:** todo `Select::make(...)->relationship(...)->searchable()` que también tenga `->getOptionLabelFromRecordUsing()` debe pasarle a `searchable()` un array explícito con **todas** las columnas que aparecen en ese label override — nunca dejarlo sin argumentos cuando el label muestra más de una columna. Aplica igual a `SelectFilter::make(...)` en tablas (mismo mecanismo, ver `vendor/filament/tables/src/Filters/SelectFilter.php:260` `getFormField()`).
+
 ### Nullsafe en propiedades de relaciones en closures de columnas Filament
 
 Siempre usar `?->` al acceder a relaciones en closures de columnas — el registro relacionado puede ser null si fue eliminado:

--- a/app/Filament/Resources/AbsenceResource.php
+++ b/app/Filament/Resources/AbsenceResource.php
@@ -271,7 +271,7 @@ class AbsenceResource extends Resource
                     ->label('Empleado')
                     ->relationship('employee', 'first_name')
                     ->getOptionLabelFromRecordUsing(fn ($record) => "{$record->full_name} (CI: {$record->ci})")
-                    ->searchable()
+                    ->searchable(['first_name', 'last_name', 'ci'])
                     ->preload(false)
                     ->native(false)
                     ->multiple(),

--- a/app/Filament/Resources/AdvanceResource.php
+++ b/app/Filament/Resources/AdvanceResource.php
@@ -10,6 +10,7 @@ use App\Models\Employee;
 use App\Settings\PayrollSettings;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\Hidden;
 use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\Section;
@@ -39,6 +40,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\HtmlString;
+use Livewire\Component;
 
 class AdvanceResource extends Resource
 {
@@ -312,7 +314,7 @@ class AdvanceResource extends Resource
                                 ->color('info')
                                 ->icon('heroicon-o-building-library')
                                 ->url(fn (Advance $record) => $record->disbursement_batch_id
-                                    ? \App\Filament\Resources\DisbursementBatchResource::getUrl('view', ['record' => $record->disbursement_batch_id])
+                                    ? DisbursementBatchResource::getUrl('view', ['record' => $record->disbursement_batch_id])
                                     : null)
                                 ->openUrlInNewTab(),
 
@@ -440,7 +442,7 @@ class AdvanceResource extends Resource
                     ->label('Empleado')
                     ->relationship('employee', 'first_name')
                     ->getOptionLabelFromRecordUsing(fn ($record) => "{$record->full_name} (CI: {$record->ci})")
-                    ->searchable()
+                    ->searchable(['first_name', 'last_name', 'ci'])
                     ->multiple()
                     ->native(false),
 
@@ -600,7 +602,7 @@ class AdvanceResource extends Resource
                                 ->native(false)
                                 ->default(now())
                                 ->displayFormat('d/m/Y H:i'),
-                            \Filament\Forms\Components\FileUpload::make('transfer_receipt_path')
+                            FileUpload::make('transfer_receipt_path')
                                 ->label('Comprobante')
                                 ->disk('public')
                                 ->directory('advances/receipts')
@@ -670,7 +672,7 @@ class AdvanceResource extends Resource
                         ->modalDescription('Se aprobarán los adelantos seleccionados que estén en estado Pendiente. Los demás serán ignorados.')
                         ->modalSubmitActionLabel('Sí, aprobar seleccionados')
                         ->form([
-                            \Filament\Forms\Components\Select::make('payment_method')
+                            Select::make('payment_method')
                                 ->label('Método de pago')
                                 ->options(Advance::getPaymentMethodOptions())
                                 ->default('transfer')
@@ -851,7 +853,7 @@ class AdvanceResource extends Resource
                     ->label('Descargar PDF')
                     ->icon('heroicon-o-arrow-down-tray')
                     ->color('gray')
-                    ->action(function (Collection $records, \Livewire\Component $livewire) {
+                    ->action(function (Collection $records, Component $livewire) {
                         $ids = $records->pluck('id')->implode(',');
                         $url = route('advances.pdf.bulk', ['ids' => $ids]);
                         $livewire->js("window.open('{$url}', '_blank')");

--- a/app/Filament/Resources/AguinaldoPeriodResource.php
+++ b/app/Filament/Resources/AguinaldoPeriodResource.php
@@ -56,7 +56,7 @@ class AguinaldoPeriodResource extends Resource
                     ->getOptionLabelFromRecordUsing(
                         fn (Company $record) => $record->name.($record->trade_name ? ' ('.$record->trade_name.')' : '')
                     )
-                    ->searchable()
+                    ->searchable(['name', 'trade_name'])
                     ->preload()
                     ->required()
                     ->native(false)
@@ -159,7 +159,7 @@ class AguinaldoPeriodResource extends Resource
                     ->getOptionLabelFromRecordUsing(
                         fn (Company $record) => $record->name.($record->trade_name ? ' ('.$record->trade_name.')' : '')
                     )
-                    ->searchable()
+                    ->searchable(['name', 'trade_name'])
                     ->preload()
                     ->native(false),
 

--- a/app/Filament/Resources/AguinaldoPeriodResource/RelationManagers/AguinaldosRelationManager.php
+++ b/app/Filament/Resources/AguinaldoPeriodResource/RelationManagers/AguinaldosRelationManager.php
@@ -162,7 +162,7 @@ class AguinaldosRelationManager extends RelationManager
                     ->label('Empleado')
                     ->relationship('employee', 'first_name')
                     ->getOptionLabelFromRecordUsing(fn ($record) => $record->full_name)
-                    ->searchable()
+                    ->searchable(['first_name', 'last_name'])
                     ->native(false),
             ])
             ->actions([

--- a/app/Filament/Resources/AguinaldoResource.php
+++ b/app/Filament/Resources/AguinaldoResource.php
@@ -187,7 +187,7 @@ class AguinaldoResource extends Resource
                 SelectFilter::make('employee_id')
                     ->label('Empleado')
                     ->relationship('employee', 'first_name')
-                    ->searchable()
+                    ->searchable(['first_name', 'last_name'])
                     ->native(false)
                     ->getOptionLabelFromRecordUsing(fn ($record) => $record->full_name),
 

--- a/app/Filament/Resources/AttendanceDayResource.php
+++ b/app/Filament/Resources/AttendanceDayResource.php
@@ -225,7 +225,7 @@ class AttendanceDayResource extends Resource
                     ->placeholder('Todos los empleados')
                     ->relationship('employee', 'first_name')
                     ->getOptionLabelFromRecordUsing(fn ($record) => "{$record->full_name} (CI: {$record->ci})")
-                    ->searchable()
+                    ->searchable(['first_name', 'last_name', 'ci'])
                     ->preload(false)
                     ->native(false)
                     ->multiple(),
@@ -693,7 +693,7 @@ class AttendanceDayResource extends Resource
     private static function buildTardinessModalDescription(AttendanceDay $record): string
     {
         $action = $record->tardiness_deduction_approved ? 'Se revocará el descuento de' : 'Se aprobará el descuento de';
-        $settings = app(\App\Settings\PayrollSettings::class);
+        $settings = app(PayrollSettings::class);
         $hourlyRate = $record->employee->base_salary / max(1, $settings->monthly_hours);
         $amount = round(($record->late_minutes / 60) * $hourlyRate, 2);
 
@@ -948,7 +948,7 @@ class AttendanceDayResource extends Resource
             ->icon('heroicon-o-clock')
             ->color('warning')
             ->tooltip('Cargar horas extras manualmente para este día')
-            ->mountUsing(function (\Filament\Forms\Form $form, AttendanceDay $record) {
+            ->mountUsing(function (Form $form, AttendanceDay $record) {
                 $form->fill([
                     'extra_hours_diurnas' => $record->extra_hours_diurnas ?? 0,
                     'extra_hours_nocturnas' => $record->extra_hours_nocturnas ?? 0,
@@ -1030,7 +1030,7 @@ class AttendanceDayResource extends Resource
             ->icon('heroicon-o-clock')
             ->color('warning')
             ->tooltip('Cargar horas extras manualmente para este día')
-            ->mountUsing(function (\Filament\Forms\Form $form, AttendanceDay $record) {
+            ->mountUsing(function (Form $form, AttendanceDay $record) {
                 $form->fill([
                     'extra_hours_diurnas' => $record->extra_hours_diurnas ?? 0,
                     'extra_hours_nocturnas' => $record->extra_hours_nocturnas ?? 0,

--- a/app/Filament/Resources/AttendanceEventResource.php
+++ b/app/Filament/Resources/AttendanceEventResource.php
@@ -16,6 +16,7 @@ use Filament\Forms\Get;
 use Filament\Infolists\Components\Grid;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Infolists\Components\ViewEntry;
+use Filament\Resources\Pages\PageRegistration;
 use Filament\Resources\Resource;
 use Filament\Tables\Actions\ActionGroup;
 use Filament\Tables\Actions\DeleteAction;
@@ -139,7 +140,7 @@ class AttendanceEventResource extends Resource
                     ->getOptionLabelFromRecordUsing(
                         fn ($record) => $record->first_name.' '.$record->last_name.' (CI: '.$record->ci.')'
                     )
-                    ->searchable()
+                    ->searchable(['first_name', 'last_name', 'ci'])
                     ->preload(false)
                     ->native(false)
                     ->multiple(),
@@ -308,7 +309,7 @@ class AttendanceEventResource extends Resource
     /**
      * Registra las páginas del recurso.
      *
-     * @return array<string, \Filament\Resources\Pages\PageRegistration>
+     * @return array<string, PageRegistration>
      */
     public static function getPages(): array
     {

--- a/app/Filament/Resources/BranchResource.php
+++ b/app/Filament/Resources/BranchResource.php
@@ -15,6 +15,8 @@ use Filament\Forms\Get;
 use Filament\Infolists\Components\Section as InfoSection;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Infolists\Infolist;
+use Filament\Resources\Pages\PageRegistration;
+use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Resources\Resource;
 use Filament\Tables\Actions\Action;
 use Filament\Tables\Actions\BulkActionGroup;
@@ -60,7 +62,7 @@ class BranchResource extends Resource
                         ->getOptionLabelFromRecordUsing(
                             fn (Company $record) => $record->name.($record->trade_name ? ' ('.$record->trade_name.')' : '')
                         )
-                        ->searchable()
+                        ->searchable(['name', 'trade_name'])
                         ->preload()
                         ->required()
                         ->helperText('Empresa a la que pertenece esta sucursal.'),
@@ -265,7 +267,7 @@ class BranchResource extends Resource
                     ->getOptionLabelFromRecordUsing(
                         fn (Company $record) => $record->name.($record->trade_name ? ' ('.$record->trade_name.')' : '')
                     )
-                    ->searchable()
+                    ->searchable(['name', 'trade_name'])
                     ->preload()
                     ->placeholder('Todas las empresas'),
 
@@ -313,7 +315,7 @@ class BranchResource extends Resource
     /**
      * Retorna los relation managers asociados al recurso.
      *
-     * @return array<class-string<\Filament\Resources\RelationManagers\RelationManager>>
+     * @return array<class-string<RelationManager>>
      */
     public static function getRelations(): array
     {
@@ -325,7 +327,7 @@ class BranchResource extends Resource
     /**
      * Retorna las páginas registradas para este recurso.
      *
-     * @return array<string, \Filament\Resources\Pages\PageRegistration>
+     * @return array<string, PageRegistration>
      */
     public static function getPages(): array
     {

--- a/app/Filament/Resources/ContractResource.php
+++ b/app/Filament/Resources/ContractResource.php
@@ -705,7 +705,7 @@ class ContractResource extends Resource
                     ->label('Empleado')
                     ->relationship('employee', 'first_name')
                     ->getOptionLabelFromRecordUsing(fn ($record) => "{$record->full_name} (CI: {$record->ci})")
-                    ->searchable()
+                    ->searchable(['first_name', 'last_name', 'ci'])
                     ->preload(false)
                     ->native(false),
 

--- a/app/Filament/Resources/EmployeeLeaveResource.php
+++ b/app/Filament/Resources/EmployeeLeaveResource.php
@@ -21,6 +21,7 @@ use Filament\Infolists\Components\Section as InfolistSection;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Infolists\Infolist;
 use Filament\Notifications\Notification;
+use Filament\Resources\Pages\PageRegistration;
 use Filament\Resources\Resource;
 use Filament\Tables\Actions\Action;
 use Filament\Tables\Actions\ActionGroup;
@@ -302,7 +303,7 @@ class EmployeeLeaveResource extends Resource
                     ->label('Empleado')
                     ->relationship('employee', 'first_name')
                     ->getOptionLabelFromRecordUsing(fn ($record) => "{$record->first_name} {$record->last_name}")
-                    ->searchable()
+                    ->searchable(['first_name', 'last_name'])
                     ->preload()
                     ->multiple(),
             ])
@@ -556,7 +557,7 @@ class EmployeeLeaveResource extends Resource
     /**
      * Registra las páginas del recurso.
      *
-     * @return array<string, \Filament\Resources\Pages\PageRegistration>
+     * @return array<string, PageRegistration>
      */
     public static function getRelations(): array
     {

--- a/app/Filament/Resources/EmployeeResource/RelationManagers/EmployeeDeductionsRelationManager.php
+++ b/app/Filament/Resources/EmployeeResource/RelationManagers/EmployeeDeductionsRelationManager.php
@@ -65,6 +65,7 @@ class EmployeeDeductionsRelationManager extends RelationManager
                     ->label('Deducción')
                     ->relationship(
                         name: 'deduction',
+                        titleAttribute: 'name',
                         modifyQueryUsing: fn (Builder $query) => $query->where('is_active', true)->orderBy('name')
                     )
                     ->getOptionLabelFromRecordUsing(
@@ -75,7 +76,7 @@ class EmployeeDeductionsRelationManager extends RelationManager
                             ).')'
                     )
                     ->required()
-                    ->searchable()
+                    ->searchable(['name', 'code'])
                     ->preload()
                     ->live()
                     ->native(false)

--- a/app/Filament/Resources/EmployeeResource/RelationManagers/EmployeePerceptionsRelationManager.php
+++ b/app/Filament/Resources/EmployeeResource/RelationManagers/EmployeePerceptionsRelationManager.php
@@ -63,6 +63,7 @@ class EmployeePerceptionsRelationManager extends RelationManager
                     ->label('Percepción')
                     ->relationship(
                         name: 'perception',
+                        titleAttribute: 'name',
                         modifyQueryUsing: fn (Builder $query) => $query->where('is_active', true)->orderBy('name')
                     )
                     ->getOptionLabelFromRecordUsing(
@@ -73,7 +74,7 @@ class EmployeePerceptionsRelationManager extends RelationManager
                             ).')'
                     )
                     ->required()
-                    ->searchable()
+                    ->searchable(['name', 'code'])
                     ->preload()
                     ->live()
                     ->afterStateUpdated(fn (Set $set) => $set('custom_amount', null))

--- a/app/Filament/Resources/FaceEnrollmentResource.php
+++ b/app/Filament/Resources/FaceEnrollmentResource.php
@@ -164,7 +164,7 @@ class FaceEnrollmentResource extends Resource
                     ->label('Empleado')
                     ->relationship('employee', 'first_name')
                     ->getOptionLabelFromRecordUsing(fn ($record) => "{$record->full_name} (CI: {$record->ci})")
-                    ->searchable()
+                    ->searchable(['first_name', 'last_name', 'ci'])
                     ->preload(false)
                     ->native(false),
             ])

--- a/app/Filament/Resources/LiquidacionResource.php
+++ b/app/Filament/Resources/LiquidacionResource.php
@@ -30,6 +30,7 @@ use Filament\Tables\Actions\DeleteBulkAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
+use Illuminate\Support\HtmlString;
 use pxlrbt\FilamentExcel\Actions\Pages\ExportAction;
 use pxlrbt\FilamentExcel\Columns\Column;
 use pxlrbt\FilamentExcel\Exports\ExcelExport;
@@ -242,7 +243,7 @@ class LiquidacionResource extends Resource
                                     return null;
                                 }
 
-                                return new \Illuminate\Support\HtmlString(
+                                return new HtmlString(
                                     '<div style="background:#fef3c7;border:1px solid #d97706;border-radius:6px;padding:10px 14px;color:#92400e;">'
                                     .'<strong>⚠ Estabilidad Laboral Propia — Art. 95 CLT</strong><br>'
                                     ."Este empleado cuenta con <strong>{$years} años</strong> de antigüedad. "
@@ -369,7 +370,7 @@ class LiquidacionResource extends Resource
                     ->label('Empleado')
                     ->relationship('employee', 'first_name')
                     ->getOptionLabelFromRecordUsing(fn ($record) => $record->full_name)
-                    ->searchable()
+                    ->searchable(['first_name', 'last_name'])
                     ->preload()
                     ->native(false),
             ])

--- a/app/Filament/Resources/LoanResource.php
+++ b/app/Filament/Resources/LoanResource.php
@@ -464,7 +464,7 @@ class LoanResource extends Resource
                     ->label('Empleado')
                     ->relationship('employee', 'first_name')
                     ->getOptionLabelFromRecordUsing(fn ($record) => "{$record->full_name} (CI: {$record->ci})")
-                    ->searchable()
+                    ->searchable(['first_name', 'last_name', 'ci'])
                     ->multiple()
                     ->native(false),
 

--- a/app/Filament/Resources/MerchandiseWithdrawalResource.php
+++ b/app/Filament/Resources/MerchandiseWithdrawalResource.php
@@ -20,6 +20,7 @@ use Filament\Infolists\Components\Section as InfolistSection;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Infolists\Infolist;
 use Filament\Notifications\Notification;
+use Filament\Resources\Pages\PageRegistration;
 use Filament\Resources\Resource;
 use Filament\Tables\Actions\Action;
 use Filament\Tables\Actions\BulkActionGroup;
@@ -331,7 +332,7 @@ class MerchandiseWithdrawalResource extends Resource
                     ->label('Empleado')
                     ->relationship('employee', 'first_name')
                     ->getOptionLabelFromRecordUsing(fn ($record) => "{$record->full_name} (CI: {$record->ci})")
-                    ->searchable()
+                    ->searchable(['first_name', 'last_name', 'ci'])
                     ->multiple()
                     ->native(false),
             ])
@@ -408,7 +409,7 @@ class MerchandiseWithdrawalResource extends Resource
     /**
      * Páginas del resource.
      *
-     * @return array<string, \Filament\Resources\Pages\PageRegistration>
+     * @return array<string, PageRegistration>
      */
     public static function getPages(): array
     {

--- a/app/Filament/Resources/PayrollResource.php
+++ b/app/Filament/Resources/PayrollResource.php
@@ -24,6 +24,8 @@ use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Livewire\Component;
 use Maatwebsite\Excel\Excel;
 use pxlrbt\FilamentExcel\Actions\Tables\ExportBulkAction;
 use pxlrbt\FilamentExcel\Exports\ExcelExport;
@@ -172,7 +174,7 @@ class PayrollResource extends Resource
                 SelectFilter::make('employee_id')
                     ->label('Empleado')
                     ->relationship('employee', 'first_name')
-                    ->searchable()
+                    ->searchable(['first_name', 'last_name'])
                     ->preload()
                     ->native(false)
                     ->getOptionLabelFromRecordUsing(function ($record) {
@@ -488,7 +490,7 @@ class PayrollResource extends Resource
                         ->label('Descargar PDFs')
                         ->icon('heroicon-o-arrow-down-tray')
                         ->color('gray')
-                        ->action(function (Collection $records, \Livewire\Component $livewire) {
+                        ->action(function (Collection $records, Component $livewire) {
                             $records->load('employee');
                             $validRecords = $records->filter(
                                 fn (Payroll $r) => $r->pdf_path && Storage::disk('public')->exists($r->pdf_path)
@@ -516,7 +518,7 @@ class PayrollResource extends Resource
                                 }
                             }
 
-                            $uniqueId = \Illuminate\Support\Str::uuid();
+                            $uniqueId = Str::uuid();
 
                             if ($validRecords->count() === 1) {
                                 $record = $validRecords->first();

--- a/app/Filament/Resources/VacationResource.php
+++ b/app/Filament/Resources/VacationResource.php
@@ -432,7 +432,7 @@ class VacationResource extends Resource
                     ->label('Empleado')
                     ->relationship('employee', 'first_name')
                     ->getOptionLabelFromRecordUsing(fn ($record) => "{$record->full_name} (CI: {$record->ci})")
-                    ->searchable()
+                    ->searchable(['first_name', 'last_name', 'ci'])
                     ->preload()
                     ->native(false),
 

--- a/app/Filament/Resources/VacationResource.php
+++ b/app/Filament/Resources/VacationResource.php
@@ -16,6 +16,7 @@ use Filament\Forms\Components\Hidden;
 use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
 use Filament\Forms\Set;
@@ -68,8 +69,8 @@ class VacationResource extends Resource
                     ->schema([
                         Select::make('employee_id')
                             ->label('Empleado')
-                            ->relationship('employee', 'id', fn ($query) => $query->where('status', 'active')->orderBy('first_name'))
-                            ->searchable()
+                            ->relationship('employee', 'first_name', fn ($query) => $query->where('status', 'active')->orderBy('first_name'))
+                            ->searchable(['first_name', 'last_name', 'ci'])
                             ->preload()
                             ->native(false)
                             ->required()
@@ -272,7 +273,7 @@ class VacationResource extends Resource
                                 if ($employeeId && $businessDays > 0) {
                                     $employee = Employee::find($employeeId);
                                     if ($employee instanceof Employee) {
-                                        $tempVacation = new \App\Models\Vacation([
+                                        $tempVacation = new Vacation([
                                             'employee_id' => $employee->id,
                                             'start_date' => $startDate,
                                             'end_date' => $endDate,
@@ -316,7 +317,7 @@ class VacationResource extends Resource
                             })
                             ->columnSpanFull(),
 
-                        \Filament\Forms\Components\Textarea::make('reason')
+                        Textarea::make('reason')
                             ->label('Motivo / observaciones')
                             ->placeholder('Opcional: notas sobre este período de vacaciones…')
                             ->rows(2)

--- a/app/Filament/Resources/WarningResource.php
+++ b/app/Filament/Resources/WarningResource.php
@@ -293,7 +293,7 @@ class WarningResource extends Resource
                     ->label('Empleado')
                     ->relationship('employee', 'first_name')
                     ->getOptionLabelFromRecordUsing(fn ($record) => "{$record->full_name} (CI: {$record->ci})")
-                    ->searchable()
+                    ->searchable(['first_name', 'last_name', 'ci'])
                     ->multiple()
                     ->native(false),
 

--- a/app/Filament/Widgets/LatestAttendances.php
+++ b/app/Filament/Widgets/LatestAttendances.php
@@ -94,7 +94,7 @@ class LatestAttendances extends BaseWidget
                     ->getOptionLabelFromRecordUsing(
                         fn ($record) => $record->first_name.' '.$record->last_name.' (CI: '.$record->ci.')'
                     )
-                    ->searchable()
+                    ->searchable(['first_name', 'last_name', 'ci'])
                     ->preload(false)
                     ->native(false)
                     ->multiple(),

--- a/tests/Feature/AbsenceResourceFilterTest.php
+++ b/tests/Feature/AbsenceResourceFilterTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Filament\Resources\AbsenceResource\Pages\ListAbsences;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión: el filtro de empleado mostraba nombre completo+CI pero solo
+ * buscaba por 'first_name' (relationshipTitleAttribute), por ->searchable()
+ * sin array explícito.
+ */
+it('busca el empleado por nombre, apellido o CI en el filtro de tabla de ausencias', function () {
+    $this->actingAs(User::factory()->create());
+
+    $filter = Livewire::test(ListAbsences::class)
+        ->instance()
+        ->getTable()
+        ->getFilter('employee_id');
+
+    expect($filter->getFormField()->getSearchColumns())->toBe(['first_name', 'last_name', 'ci']);
+});

--- a/tests/Feature/AdvanceResourceFilterTest.php
+++ b/tests/Feature/AdvanceResourceFilterTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Filament\Resources\AdvanceResource\Pages\ListAdvances;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión: el filtro de empleado mostraba nombre completo+CI pero solo
+ * buscaba por 'first_name' (relationshipTitleAttribute), por ->searchable()
+ * sin array explícito.
+ */
+it('busca el empleado por nombre, apellido o CI en el filtro de tabla de adelantos', function () {
+    $this->actingAs(User::factory()->create());
+
+    $filter = Livewire::test(ListAdvances::class)
+        ->instance()
+        ->getTable()
+        ->getFilter('employee_id');
+
+    expect($filter->getFormField()->getSearchColumns())->toBe(['first_name', 'last_name', 'ci']);
+});

--- a/tests/Feature/AguinaldoPeriodResourceSearchTest.php
+++ b/tests/Feature/AguinaldoPeriodResourceSearchTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Filament\Resources\AguinaldoPeriodResource\Pages\CreateAguinaldoPeriod;
+use App\Filament\Resources\AguinaldoPeriodResource\Pages\ListAguinaldoPeriods;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión: el select de empresa muestra nombre + nombre comercial
+ * (trade_name), pero solo buscaba por 'name' (relationshipTitleAttribute),
+ * por ->searchable() sin array explícito.
+ */
+it('busca la empresa por nombre o nombre comercial en el form de períodos de aguinaldo', function () {
+    $this->actingAs(User::factory()->create());
+
+    $field = Livewire::test(CreateAguinaldoPeriod::class)
+        ->instance()
+        ->form
+        ->getFlatFields(withHidden: true)['company_id'];
+
+    expect($field->getSearchColumns())->toBe(['name', 'trade_name']);
+});
+
+it('busca la empresa por nombre o nombre comercial en el filtro de tabla de períodos de aguinaldo', function () {
+    $this->actingAs(User::factory()->create());
+
+    $filter = Livewire::test(ListAguinaldoPeriods::class)
+        ->instance()
+        ->getTable()
+        ->getFilter('company_id');
+
+    expect($filter->getFormField()->getSearchColumns())->toBe(['name', 'trade_name']);
+});

--- a/tests/Feature/AguinaldoResourceFilterTest.php
+++ b/tests/Feature/AguinaldoResourceFilterTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Filament\Resources\AguinaldoResource\Pages\ListAguinaldos;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión: el filtro de empleado mostraba el nombre completo pero solo
+ * buscaba por 'first_name' (relationshipTitleAttribute), por ->searchable()
+ * sin array explícito.
+ */
+it('busca el empleado por nombre o apellido en el filtro de tabla de aguinaldos', function () {
+    $this->actingAs(User::factory()->create());
+
+    $filter = Livewire::test(ListAguinaldos::class)
+        ->instance()
+        ->getTable()
+        ->getFilter('employee_id');
+
+    expect($filter->getFormField()->getSearchColumns())->toBe(['first_name', 'last_name']);
+});

--- a/tests/Feature/AguinaldosRelationManagerFilterTest.php
+++ b/tests/Feature/AguinaldosRelationManagerFilterTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use App\Filament\Resources\AguinaldoPeriodResource\Pages\ViewAguinaldoPeriod;
+use App\Filament\Resources\AguinaldoPeriodResource\RelationManagers\AguinaldosRelationManager;
+use App\Models\AguinaldoPeriod;
+use App\Models\Company;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión: el filtro de empleado mostraba el nombre completo pero solo
+ * buscaba por 'first_name' (relationshipTitleAttribute), por ->searchable()
+ * sin array explícito.
+ */
+it('busca el empleado por nombre o apellido en el filtro del RelationManager de aguinaldos del período', function () {
+    $this->actingAs(User::factory()->create());
+
+    $company = Company::create([
+        'name' => 'Empresa Test Agu',
+        'ruc' => '9000000-1',
+        'employer_number' => 9000000,
+    ]);
+
+    $period = AguinaldoPeriod::create([
+        'company_id' => $company->id,
+        'year' => 2025,
+        'status' => 'draft',
+    ]);
+
+    $filter = Livewire::test(AguinaldosRelationManager::class, [
+        'ownerRecord' => $period,
+        'pageClass' => ViewAguinaldoPeriod::class,
+    ])
+        ->instance()
+        ->getTable()
+        ->getFilter('employee_id');
+
+    expect($filter->getFormField()->getSearchColumns())->toBe(['first_name', 'last_name']);
+});

--- a/tests/Feature/AttendanceDayResourceFilterTest.php
+++ b/tests/Feature/AttendanceDayResourceFilterTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Filament\Resources\AttendanceDayResource\Pages\ListAttendanceDays;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión: el filtro de empleado mostraba nombre completo+CI pero solo
+ * buscaba por 'first_name' (relationshipTitleAttribute), por ->searchable()
+ * sin array explícito.
+ */
+it('busca el empleado por nombre, apellido o CI en el filtro de tabla de asistencia diaria', function () {
+    $this->actingAs(User::factory()->create());
+
+    $filter = Livewire::test(ListAttendanceDays::class)
+        ->instance()
+        ->getTable()
+        ->getFilter('employee_id');
+
+    expect($filter->getFormField()->getSearchColumns())->toBe(['first_name', 'last_name', 'ci']);
+});

--- a/tests/Feature/AttendanceEventResourceFilterTest.php
+++ b/tests/Feature/AttendanceEventResourceFilterTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Filament\Resources\AttendanceEventResource\Pages\ManageAttendanceEvents;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión: el filtro de empleado mostraba nombre completo+CI pero solo
+ * buscaba por 'first_name' (relationshipTitleAttribute), por ->searchable()
+ * sin array explícito.
+ */
+it('busca el empleado por nombre, apellido o CI en el filtro de tabla de marcaciones', function () {
+    $this->actingAs(User::factory()->create());
+
+    $filter = Livewire::test(ManageAttendanceEvents::class)
+        ->instance()
+        ->getTable()
+        ->getFilter('employee_id');
+
+    expect($filter->getFormField()->getSearchColumns())->toBe(['first_name', 'last_name', 'ci']);
+});

--- a/tests/Feature/BranchResourceSearchTest.php
+++ b/tests/Feature/BranchResourceSearchTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\Filament\Resources\BranchResource\Pages\CreateBranch;
+use App\Filament\Resources\BranchResource\Pages\ListBranches;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión: el select de empresa muestra nombre + nombre comercial
+ * (trade_name), pero solo buscaba por 'name' (relationshipTitleAttribute),
+ * por ->searchable() sin array explícito.
+ */
+it('busca la empresa por nombre o nombre comercial en el form de sucursales', function () {
+    $this->actingAs(User::factory()->create());
+
+    // El form de sucursales incluye un campo Map (filament-google-maps) que
+    // requiere una API key configurada para renderizar — sin relación con
+    // este fix, solo necesario para que el form monte en el entorno de test.
+    config(['filament-google-maps.keys.web_key' => 'test-key']);
+
+    $field = Livewire::test(CreateBranch::class)
+        ->instance()
+        ->form
+        ->getFlatFields(withHidden: true)['company_id'];
+
+    expect($field->getSearchColumns())->toBe(['name', 'trade_name']);
+});
+
+it('busca la empresa por nombre o nombre comercial en el filtro de tabla de sucursales', function () {
+    $this->actingAs(User::factory()->create());
+
+    $filter = Livewire::test(ListBranches::class)
+        ->instance()
+        ->getTable()
+        ->getFilter('company_id');
+
+    expect($filter->getFormField()->getSearchColumns())->toBe(['name', 'trade_name']);
+});

--- a/tests/Feature/ContractResourceFilterTest.php
+++ b/tests/Feature/ContractResourceFilterTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Filament\Resources\ContractResource\Pages\ListContracts;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión: el filtro de empleado mostraba nombre completo+CI pero solo
+ * buscaba por 'first_name' (relationshipTitleAttribute), por ->searchable()
+ * sin array explícito.
+ */
+it('busca el empleado por nombre, apellido o CI en el filtro de tabla de contratos', function () {
+    $this->actingAs(User::factory()->create());
+
+    $filter = Livewire::test(ListContracts::class)
+        ->instance()
+        ->getTable()
+        ->getFilter('employee_id');
+
+    expect($filter->getFormField()->getSearchColumns())->toBe(['first_name', 'last_name', 'ci']);
+});

--- a/tests/Feature/EmployeeDeductionsRelationManagerSearchTest.php
+++ b/tests/Feature/EmployeeDeductionsRelationManagerSearchTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Filament\Resources\EmployeeResource\Pages\EditEmployee;
+use App\Filament\Resources\EmployeeResource\RelationManagers\EmployeeDeductionsRelationManager;
+use App\Models\Branch;
+use App\Models\Company;
+use App\Models\Employee;
+use App\Models\User;
+use Filament\Forms\Form;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión: el select de deducción se creaba con ->relationship('deduction', ...)
+ * sin titleAttribute — Filament no tenía columna de referencia para buscar y el
+ * buscador quedaba completamente inerte (no filtraba nada, ni siquiera fallaba).
+ */
+it('busca la deducción por nombre o código en el RelationManager de deducciones del empleado', function () {
+    $this->actingAs(User::factory()->create());
+
+    $company = Company::create(['name' => 'Empresa Ded', 'ruc' => '9200000-1', 'employer_number' => 9200000]);
+    $branch = Branch::create(['name' => 'Sucursal Ded', 'company_id' => $company->id]);
+    $employee = Employee::factory()->create(['branch_id' => $branch->id]);
+
+    $instance = Livewire::test(EmployeeDeductionsRelationManager::class, [
+        'ownerRecord' => $employee,
+        'pageClass' => EditEmployee::class,
+    ])->instance();
+
+    $field = $instance->form(Form::make($instance))
+        ->getFlatFields(withHidden: true)['deduction_id'];
+
+    expect($field->getSearchColumns())->toBe(['name', 'code']);
+});

--- a/tests/Feature/EmployeeLeaveResourceFilterTest.php
+++ b/tests/Feature/EmployeeLeaveResourceFilterTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Filament\Resources\EmployeeLeaveResource\Pages\ListEmployeeLeaves;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión: el filtro de empleado mostraba nombre completo pero solo
+ * buscaba por 'first_name' (relationshipTitleAttribute), por ->searchable()
+ * sin array explícito.
+ */
+it('busca el empleado por nombre o apellido en el filtro de tabla de permisos y licencias', function () {
+    $this->actingAs(User::factory()->create());
+
+    $filter = Livewire::test(ListEmployeeLeaves::class)
+        ->instance()
+        ->getTable()
+        ->getFilter('employee_id');
+
+    expect($filter->getFormField()->getSearchColumns())->toBe(['first_name', 'last_name']);
+});

--- a/tests/Feature/EmployeePerceptionsRelationManagerSearchTest.php
+++ b/tests/Feature/EmployeePerceptionsRelationManagerSearchTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Filament\Resources\EmployeeResource\Pages\EditEmployee;
+use App\Filament\Resources\EmployeeResource\RelationManagers\EmployeePerceptionsRelationManager;
+use App\Models\Branch;
+use App\Models\Company;
+use App\Models\Employee;
+use App\Models\User;
+use Filament\Forms\Form;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión: el select de percepción se creaba con ->relationship('perception', ...)
+ * sin titleAttribute — Filament no tenía columna de referencia para buscar y el
+ * buscador quedaba completamente inerte (no filtraba nada, ni siquiera fallaba).
+ */
+it('busca la percepción por nombre o código en el RelationManager de percepciones del empleado', function () {
+    $this->actingAs(User::factory()->create());
+
+    $company = Company::create(['name' => 'Empresa Perc', 'ruc' => '9100000-1', 'employer_number' => 9100000]);
+    $branch = Branch::create(['name' => 'Sucursal Perc', 'company_id' => $company->id]);
+    $employee = Employee::factory()->create(['branch_id' => $branch->id]);
+
+    $instance = Livewire::test(EmployeePerceptionsRelationManager::class, [
+        'ownerRecord' => $employee,
+        'pageClass' => EditEmployee::class,
+    ])->instance();
+
+    $field = $instance->form(Form::make($instance))
+        ->getFlatFields(withHidden: true)['perception_id'];
+
+    expect($field->getSearchColumns())->toBe(['name', 'code']);
+});

--- a/tests/Feature/FaceEnrollmentResourceFilterTest.php
+++ b/tests/Feature/FaceEnrollmentResourceFilterTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Filament\Resources\FaceEnrollmentResource\Pages\ListFaceEnrollments;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión: el filtro de empleado mostraba nombre completo+CI pero solo
+ * buscaba por 'first_name' (relationshipTitleAttribute), por ->searchable()
+ * sin array explícito.
+ */
+it('busca el empleado por nombre, apellido o CI en el filtro de tabla de enrolamientos faciales', function () {
+    $this->actingAs(User::factory()->create());
+
+    $filter = Livewire::test(ListFaceEnrollments::class)
+        ->instance()
+        ->getTable()
+        ->getFilter('employee_id');
+
+    expect($filter->getFormField()->getSearchColumns())->toBe(['first_name', 'last_name', 'ci']);
+});

--- a/tests/Feature/LatestAttendancesWidgetTest.php
+++ b/tests/Feature/LatestAttendancesWidgetTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Filament\Widgets\LatestAttendances;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión: el filtro de empleado en el widget de últimas marcaciones
+ * mostraba nombre+apellido+CI pero solo buscaba por 'first_name'
+ * (relationshipTitleAttribute), por ->searchable() sin array explícito.
+ */
+it('busca el empleado por nombre, apellido o CI en el filtro del widget de últimas marcaciones', function () {
+    $this->actingAs(User::factory()->create());
+
+    $filter = Livewire::test(LatestAttendances::class)
+        ->instance()
+        ->getTable()
+        ->getFilter('employee_id');
+
+    expect($filter->getFormField()->getSearchColumns())->toBe(['first_name', 'last_name', 'ci']);
+});

--- a/tests/Feature/LiquidacionResourceFilterTest.php
+++ b/tests/Feature/LiquidacionResourceFilterTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Filament\Resources\LiquidacionResource\Pages\ListLiquidaciones;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión: el filtro de empleado mostraba nombre completo pero solo
+ * buscaba por 'first_name' (relationshipTitleAttribute), por ->searchable()
+ * sin array explícito.
+ */
+it('busca el empleado por nombre o apellido en el filtro de tabla de liquidaciones', function () {
+    $this->actingAs(User::factory()->create());
+
+    $filter = Livewire::test(ListLiquidaciones::class)
+        ->instance()
+        ->getTable()
+        ->getFilter('employee_id');
+
+    expect($filter->getFormField()->getSearchColumns())->toBe(['first_name', 'last_name']);
+});

--- a/tests/Feature/LoanResourceFilterTest.php
+++ b/tests/Feature/LoanResourceFilterTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Filament\Resources\LoanResource\Pages\ListLoans;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión: el filtro de empleado mostraba nombre completo+CI pero solo
+ * buscaba por 'first_name' (relationshipTitleAttribute), por ->searchable()
+ * sin array explícito.
+ */
+it('busca el empleado por nombre, apellido o CI en el filtro de tabla de préstamos', function () {
+    $this->actingAs(User::factory()->create());
+
+    $filter = Livewire::test(ListLoans::class)
+        ->instance()
+        ->getTable()
+        ->getFilter('employee_id');
+
+    expect($filter->getFormField()->getSearchColumns())->toBe(['first_name', 'last_name', 'ci']);
+});

--- a/tests/Feature/MerchandiseWithdrawalResourceFilterTest.php
+++ b/tests/Feature/MerchandiseWithdrawalResourceFilterTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Filament\Resources\MerchandiseWithdrawalResource\Pages\ListMerchandiseWithdrawals;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión: el filtro de empleado mostraba nombre completo+CI pero solo
+ * buscaba por 'first_name' (relationshipTitleAttribute), por ->searchable()
+ * sin array explícito.
+ */
+it('busca el empleado por nombre, apellido o CI en el filtro de tabla de retiros de mercadería', function () {
+    $this->actingAs(User::factory()->create());
+
+    $filter = Livewire::test(ListMerchandiseWithdrawals::class)
+        ->instance()
+        ->getTable()
+        ->getFilter('employee_id');
+
+    expect($filter->getFormField()->getSearchColumns())->toBe(['first_name', 'last_name', 'ci']);
+});

--- a/tests/Feature/PayrollResourceFilterTest.php
+++ b/tests/Feature/PayrollResourceFilterTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Filament\Resources\PayrollResource\Pages\ListPayrolls;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión: el filtro de empleado mostraba nombre completo pero solo
+ * buscaba por 'first_name' (relationshipTitleAttribute), por ->searchable()
+ * sin array explícito.
+ */
+it('busca el empleado por nombre o apellido en el filtro de tabla de nóminas', function () {
+    $this->actingAs(User::factory()->create());
+
+    $filter = Livewire::test(ListPayrolls::class)
+        ->instance()
+        ->getTable()
+        ->getFilter('employee_id');
+
+    expect($filter->getFormField()->getSearchColumns())->toBe(['first_name', 'last_name']);
+});

--- a/tests/Feature/VacationResourceFormTest.php
+++ b/tests/Feature/VacationResourceFormTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Filament\Resources\VacationResource\Pages\CreateVacation;
+use App\Filament\Resources\VacationResource\Pages\ListVacations;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
@@ -22,4 +23,20 @@ it('busca el empleado por nombre, apellido o CI en el select de vacaciones, no s
         ->getFlatFields(withHidden: true)['employee_id'];
 
     expect($field->getSearchColumns())->toBe(['first_name', 'last_name', 'ci']);
+});
+
+/**
+ * Regresión: el mismo bug existía en el filtro de tabla employee_id
+ * (->relationship('employee', 'first_name') + ->searchable() sin array),
+ * pero el label mostrado (full_name + CI) no era buscable con el fallback.
+ */
+it('busca el empleado por nombre, apellido o CI en el filtro de tabla de vacaciones', function () {
+    $this->actingAs(User::factory()->create());
+
+    $filter = Livewire::test(ListVacations::class)
+        ->instance()
+        ->getTable()
+        ->getFilter('employee_id');
+
+    expect($filter->getFormField()->getSearchColumns())->toBe(['first_name', 'last_name', 'ci']);
 });

--- a/tests/Feature/VacationResourceFormTest.php
+++ b/tests/Feature/VacationResourceFormTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use App\Filament\Resources\VacationResource\Pages\CreateVacation;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión: el selector de empleado en el form de Vacaciones usaba 'id' como
+ * relationshipTitleAttribute sin un ->searchable([...]) explícito, por lo que
+ * Filament buscaba contra la columna `id` en vez del nombre — un empleado
+ * activo no aparecía al buscarlo por nombre, solo escribiendo su ID numérico.
+ */
+it('busca el empleado por nombre, apellido o CI en el select de vacaciones, no solo por id', function () {
+    $this->actingAs(User::factory()->create());
+
+    $field = Livewire::test(CreateVacation::class)
+        ->instance()
+        ->form
+        ->getFlatFields(withHidden: true)['employee_id'];
+
+    expect($field->getSearchColumns())->toBe(['first_name', 'last_name', 'ci']);
+});

--- a/tests/Feature/WarningResourceFilterTest.php
+++ b/tests/Feature/WarningResourceFilterTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Filament\Resources\WarningResource\Pages\ListWarnings;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Regresión: el filtro de empleado mostraba nombre completo+CI pero solo
+ * buscaba por 'first_name' (relationshipTitleAttribute), por ->searchable()
+ * sin array explícito.
+ */
+it('busca el empleado por nombre, apellido o CI en el filtro de tabla de amonestaciones', function () {
+    $this->actingAs(User::factory()->create());
+
+    $filter = Livewire::test(ListWarnings::class)
+        ->instance()
+        ->getTable()
+        ->getFilter('employee_id');
+
+    expect($filter->getFormField()->getSearchColumns())->toBe(['first_name', 'last_name', 'ci']);
+});


### PR DESCRIPTION
## Summary

A Macro client user reported being unable to find an active employee (#116, Liza Zarza) in the employee selector on the Vacations creation form, despite the employee meeting all requirements. Root cause: the `Select::make('employee_id')->relationship('employee', 'id', ...)` field used `'id'` as the relationship's `titleAttribute` combined with a bare `->searchable()` (no explicit column array). Filament 3 falls back to searching only against `titleAttribute` when `searchable()` receives no array (`Select::getSearchColumns()`), so the search box filtered against `employees.id` instead of the name shown in the label — typing a name found nothing; only the literal numeric ID worked.

After fixing the reported field, an audit of the entire `app/Filament/` tree (agent-assisted, then manually verified) found the same pattern repeated systemically:

- **16 table filters** (`SelectFilter::make('employee_id')`) across almost every Resource — same root cause, label shows more than `titleAttribute` covers.
- **2 RelationManager selects** (`EmployeePerceptionsRelationManager`, `EmployeeDeductionsRelationManager`) where `titleAttribute` was omitted entirely — search was completely inert (didn't filter anything, didn't even fail).
- **4 company selects** (`BranchResource`, `AguinaldoPeriodResource`, form + filter each) where the label appends `trade_name` to a `titleAttribute='name'` that doesn't cover it.

Two related-but-distinct issues were found and intentionally **left out of this PR** (documented in the investigation, not silently dropped):
- `PositionResource` department/period selects where the label adds a parent's name across a joined table — low impact (primary search term still works), would need a custom `getSearchResultsUsing()` closure rather than a simple array.
- `PositionResource`'s `parent_id` select combines `->relationship()` (live search, no exclusion) with a separate `->options()` closure (excludes self/descendants to prevent hierarchy cycles) — the live search bypasses that exclusion. This is a data-integrity bug, not a search-UX bug, and needs its own design/fix.

## Changes

- 22 `->searchable([...])` fixes across 20 files, each array matching the exact columns shown in that field's `getOptionLabelFromRecordUsing()` override.
- 1 regression test per touched file (23 new/extended test cases total), using `Livewire::test(...)->getSearchColumns()` / `SelectFilter::getFormField()->getSearchColumns()` to assert the fix without needing to simulate browser typing.
- New `CLAUDE.md` convention section documenting this Filament gotcha so it isn't reintroduced.
- Also includes `.github/workflows/tests.yml` (CI check on PRs) and a `CLAUDE.md` correction about Macro's deploy process, from earlier commits on this branch.

## Test plan

- [x] `php artisan test --compact` — full suite green: 404 tests, 796 assertions.
- [x] `vendor/bin/pint --dirty` applied to all touched files.
- [x] Manually confirmed in Tinker/browser that employee #116 now appears when searching by name in the Vacations form.
- [ ] Spot-check 2-3 of the newly fixed table filters in a running instance (recommended before merging, not done in this session — no live browser access to this environment).

https://claude.ai/code/session_01K852zqbBonRF8BqgLenZw4


---
_Generated by [Claude Code](https://claude.ai/code/session_01K852zqbBonRF8BqgLenZw4)_