### PR TITLE
Mejorar marcación de asistencia: confiabilidad facial + base offline (Sanctum API)

### DIFF
--- a/app/Filament/Resources/AttendanceMarkFailureResource/Pages/ListAttendanceMarkFailures.php
+++ b/app/Filament/Resources/AttendanceMarkFailureResource/Pages/ListAttendanceMarkFailures.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\AttendanceMarkFailureResource\Pages;
 
 use App\Filament\Resources\AttendanceMarkFailureResource;
+use App\Filament\Resources\AttendanceMarkFailureResource\Widgets\TopFailingEmployeesWidget;
 use App\Models\AttendanceMarkFailure;
 use Filament\Resources\Pages\ListRecords;
 use Filament\Resources\Pages\ListRecords\Tab;
@@ -19,6 +20,18 @@ class ListAttendanceMarkFailures extends ListRecords
     }
 
     /**
+     * Widget de diagnóstico: empleados con fallos de marcación recurrentes.
+     *
+     * @return array<class-string>
+     */
+    protected function getHeaderWidgets(): array
+    {
+        return [
+            TopFailingEmployeesWidget::class,
+        ];
+    }
+
+    /**
      * Tabs para filtrar por modo de marcación.
      *
      * @return array<string, Tab>
@@ -32,12 +45,12 @@ class ListAttendanceMarkFailures extends ListRecords
             'terminal' => Tab::make('Terminal')
                 ->badge(AttendanceMarkFailure::where('mode', 'terminal')->count())
                 ->badgeColor('info')
-                ->modifyQueryUsing(fn(Builder $query) => $query->where('mode', 'terminal')),
+                ->modifyQueryUsing(fn (Builder $query) => $query->where('mode', 'terminal')),
 
             'mobile' => Tab::make('Móvil')
                 ->badge(AttendanceMarkFailure::where('mode', 'mobile')->count())
                 ->badgeColor('success')
-                ->modifyQueryUsing(fn(Builder $query) => $query->where('mode', 'mobile')),
+                ->modifyQueryUsing(fn (Builder $query) => $query->where('mode', 'mobile')),
         ];
     }
 }

--- a/app/Filament/Resources/AttendanceMarkFailureResource/Widgets/TopFailingEmployeesWidget.php
+++ b/app/Filament/Resources/AttendanceMarkFailureResource/Widgets/TopFailingEmployeesWidget.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Filament\Resources\AttendanceMarkFailureResource\Widgets;
+
+use App\Filament\Resources\EmployeeResource;
+use App\Models\AttendanceMarkFailure;
+use App\Models\Employee;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget as BaseWidget;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+
+/**
+ * Widget de tabla: empleados con más fallos de marcación facial en los últimos días.
+ * Permite detectar proactivamente a quién le conviene re-inscribir su rostro, en vez
+ * de esperar el reclamo. Vive dentro del namespace del resource (no en Widgets/ global)
+ * para no aparecer en el Dashboard general — solo se adjunta al listado de fallos.
+ */
+class TopFailingEmployeesWidget extends BaseWidget
+{
+    protected int|string|array $columnSpan = 'full';
+
+    protected static ?string $heading = 'Empleados con más fallos de marcación (últimos 30 días)';
+
+    /** Días hacia atrás considerados en el reporte. */
+    protected int $days = 30;
+
+    /** Cantidad mínima de fallos para aparecer en el listado — evita ruido de casos aislados. */
+    protected int $minFailures = 2;
+
+    /** Cantidad máxima de empleados mostrados. */
+    protected int $limit = 15;
+
+    public function table(Table $table): Table
+    {
+        // Una sola query agregada — nunca un COUNT por empleado dentro del render de la tabla.
+        $counts = AttendanceMarkFailure::query()
+            ->where('occurred_at', '>=', now()->subDays($this->days))
+            ->whereNotNull('employee_id')
+            ->selectRaw('employee_id, COUNT(*) as total_failures, MAX(occurred_at) as last_failure_at')
+            ->groupBy('employee_id')
+            ->having('total_failures', '>=', $this->minFailures)
+            ->orderByDesc('total_failures')
+            ->limit($this->limit)
+            ->get()
+            ->keyBy('employee_id');
+
+        return $table
+            ->query($this->buildOrderedEmployeeQuery($counts))
+            ->columns([
+                TextColumn::make('full_name')
+                    ->label('Empleado')
+                    ->getStateUsing(fn (Employee $record) => "{$record->first_name} {$record->last_name}")
+                    ->description(fn (Employee $record) => $record->ci ? "CI: {$record->ci}" : null)
+                    ->weight('medium'),
+
+                TextColumn::make('branch.name')
+                    ->label('Sucursal')
+                    ->placeholder('Sin sucursal')
+                    ->badge()
+                    ->color('info'),
+
+                TextColumn::make('total_failures')
+                    ->label('Fallos')
+                    ->getStateUsing(fn (Employee $record) => $counts->get($record->id)?->total_failures ?? 0)
+                    ->badge()
+                    ->color('danger'),
+
+                TextColumn::make('last_failure_at')
+                    ->label('Último fallo')
+                    ->getStateUsing(fn (Employee $record) => $counts->get($record->id)?->last_failure_at)
+                    ->dateTime('d/m/Y H:i')
+                    ->since()
+                    ->placeholder('—'),
+            ])
+            ->recordUrl(fn (Employee $record) => EmployeeResource::getUrl('view', ['record' => $record]))
+            ->paginated(false)
+            ->emptyStateHeading('Sin empleados con fallos recurrentes')
+            ->emptyStateDescription("Ningún empleado acumuló {$this->minFailures} o más fallos de marcación en los últimos {$this->days} días.")
+            ->emptyStateIcon('heroicon-o-face-smile');
+    }
+
+    /**
+     * Arma la query de empleados ordenada por cantidad de fallos (descendente), usando
+     * el orden ya calculado en $counts en vez de dejar que whereIn() reordene libremente.
+     *
+     * @param  Collection<int, object{employee_id: int, total_failures: int, last_failure_at: string}>  $counts
+     */
+    private function buildOrderedEmployeeQuery(Collection $counts): Builder
+    {
+        $employeeIds = $counts->keys();
+
+        $query = Employee::query()->whereIn('id', $employeeIds);
+
+        if ($employeeIds->isNotEmpty()) {
+            $query->orderByRaw('FIELD(id, '.$employeeIds->implode(',').')');
+        }
+
+        return $query;
+    }
+}

--- a/app/Filament/Resources/TerminalResource.php
+++ b/app/Filament/Resources/TerminalResource.php
@@ -3,7 +3,6 @@
 namespace App\Filament\Resources;
 
 use App\Filament\Resources\TerminalResource\Pages;
-use App\Models\Branch;
 use App\Models\Terminal;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\Section;
@@ -11,19 +10,20 @@ use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
-use Filament\Infolists\Components\Group;
+use Filament\Infolists\Components\Grid as InfoGrid;
 use Filament\Infolists\Components\Section as InfoSection;
 use Filament\Infolists\Components\TextEntry;
-use Filament\Infolists\Components\Grid as InfoGrid;
 use Filament\Infolists\Infolist;
 use Filament\Notifications\Notification;
 use Filament\Resources\Resource;
 use Filament\Tables\Actions\Action;
+use Filament\Tables\Actions\ActionGroup;
 use Filament\Tables\Actions\BulkActionGroup;
 use Filament\Tables\Actions\DeleteBulkAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
+use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Auth;
 use SimpleSoftwareIO\QrCode\Facades\QrCode;
 
@@ -31,19 +31,23 @@ use SimpleSoftwareIO\QrCode\Facades\QrCode;
 class TerminalResource extends Resource
 {
     protected static ?string $model = Terminal::class;
+
     protected static ?string $navigationLabel = 'Terminales';
+
     protected static ?string $label = 'terminal';
+
     protected static ?string $pluralLabel = 'terminales';
+
     protected static ?string $slug = 'terminales';
+
     protected static ?string $navigationIcon = 'heroicon-o-computer-desktop';
+
     protected static ?string $navigationGroup = 'Asistencias';
+
     protected static ?int $navigationSort = 6;
 
     /**
      * Formulario de creación y edición de terminales.
-     *
-     * @param  Form $form
-     * @return Form
      */
     public static function form(Form $form): Form
     {
@@ -125,7 +129,7 @@ class TerminalResource extends Resource
                             ->searchable()
                             ->preload()
                             ->native(false)
-                            ->default(fn() => Auth::id()),
+                            ->default(fn () => Auth::id()),
                     ])
                     ->columns(2),
             ]);
@@ -133,9 +137,6 @@ class TerminalResource extends Resource
 
     /**
      * Infolist de visualización de la terminal con QR de acceso.
-     *
-     * @param  Infolist $infolist
-     * @return Infolist
      */
     public static function infolist(Infolist $infolist): Infolist
     {
@@ -156,8 +157,8 @@ class TerminalResource extends Resource
 
                             TextEntry::make('status')
                                 ->label('Estado')
-                                ->formatStateUsing(fn(string $state) => Terminal::getStatusLabels()[$state] ?? $state)
-                                ->color(fn(string $state) => Terminal::getStatusColors()[$state] ?? 'gray')
+                                ->formatStateUsing(fn (string $state) => Terminal::getStatusLabels()[$state] ?? $state)
+                                ->color(fn (string $state) => Terminal::getStatusColors()[$state] ?? 'gray')
                                 ->badge(),
                         ]),
 
@@ -175,15 +176,15 @@ class TerminalResource extends Resource
                                 ->icon('heroicon-o-link')
                                 ->copyable()
                                 ->copyMessage('URL copiada')
-                                ->state(fn(Terminal $record) => $record->url),
+                                ->state(fn (Terminal $record) => $record->url),
                         ]),
 
                         TextEntry::make('qr_code')
                             ->label('QR de acceso')
                             ->html()
-                            ->state(fn(Terminal $record) => '<div style="display:inline-block;background:#fff;padding:12px;border-radius:8px;border:1px solid #e5e7eb">'
-                                . QrCode::size(180)->generate($record->url)
-                                . '</div>'
+                            ->state(fn (Terminal $record) => '<div style="display:inline-block;background:#fff;padding:12px;border-radius:8px;border:1px solid #e5e7eb">'
+                                .QrCode::size(180)->generate($record->url)
+                                .'</div>'
                             ),
                     ]),
 
@@ -222,7 +223,7 @@ class TerminalResource extends Resource
                             ->placeholder('Sin notas')
                             ->columnSpanFull(),
                     ])
-                    ->visible(fn(Terminal $record) => $record->device_brand || $record->device_model || $record->device_serial || $record->device_mac || $record->device_notes),
+                    ->visible(fn (Terminal $record) => $record->device_brand || $record->device_model || $record->device_serial || $record->device_mac || $record->device_notes),
 
                 InfoSection::make('Instalación')
                     ->schema([
@@ -237,15 +238,12 @@ class TerminalResource extends Resource
                                 ->placeholder('-'),
                         ]),
                     ])
-                    ->visible(fn(Terminal $record) => $record->installed_at || $record->installed_by_id),
+                    ->visible(fn (Terminal $record) => $record->installed_at || $record->installed_by_id),
             ]);
     }
 
     /**
      * Tabla de terminales con columnas, filtros y acciones de ciclo de vida.
-     *
-     * @param  Table $table
-     * @return Table
      */
     public static function table(Table $table): Table
     {
@@ -280,8 +278,8 @@ class TerminalResource extends Resource
                 TextColumn::make('status')
                     ->label('Estado')
                     ->badge()
-                    ->formatStateUsing(fn(string $state) => Terminal::getStatusLabels()[$state] ?? $state)
-                    ->color(fn(string $state) => Terminal::getStatusColors()[$state] ?? 'gray')
+                    ->formatStateUsing(fn (string $state) => Terminal::getStatusLabels()[$state] ?? $state)
+                    ->color(fn (string $state) => Terminal::getStatusColors()[$state] ?? 'gray')
                     ->sortable(),
 
                 TextColumn::make('last_seen_at')
@@ -312,33 +310,67 @@ class TerminalResource extends Resource
                     ->native(false),
             ])
             ->actions([
-                Action::make('activate')
-                    ->label('Activar')
-                    ->icon('heroicon-o-check-circle')
-                    ->color('success')
-                    ->visible(fn(Terminal $record) => $record->isInactive())
-                    ->requiresConfirmation()
-                    ->modalHeading('Activar terminal')
-                    ->modalDescription(fn(Terminal $record) => "La terminal \"{$record->name}\" volverá a estar disponible para marcaciones.")
-                    ->modalSubmitActionLabel('Sí, activar')
-                    ->action(function (Terminal $record) {
-                        $record->update(['status' => 'active']);
-                        Notification::make()->success()->title('Terminal activada')->send();
-                    }),
+                ActionGroup::make([
+                    Action::make('activate')
+                        ->label('Activar')
+                        ->icon('heroicon-o-check-circle')
+                        ->color('success')
+                        ->visible(fn (Terminal $record) => $record->isInactive())
+                        ->requiresConfirmation()
+                        ->modalHeading('Activar terminal')
+                        ->modalDescription(fn (Terminal $record) => "La terminal \"{$record->name}\" volverá a estar disponible para marcaciones.")
+                        ->modalSubmitActionLabel('Sí, activar')
+                        ->action(function (Terminal $record) {
+                            $record->update(['status' => 'active']);
+                            Notification::make()->success()->title('Terminal activada')->send();
+                        }),
 
-                Action::make('deactivate')
-                    ->label('Desactivar')
-                    ->icon('heroicon-o-x-circle')
-                    ->color('danger')
-                    ->visible(fn(Terminal $record) => $record->isActive())
-                    ->requiresConfirmation()
-                    ->modalHeading('Desactivar terminal')
-                    ->modalDescription(fn(Terminal $record) => "La terminal \"{$record->name}\" dejará de aceptar marcaciones y mostrará una pantalla de fuera de servicio.")
-                    ->modalSubmitActionLabel('Sí, desactivar')
-                    ->action(function (Terminal $record) {
-                        $record->update(['status' => 'inactive']);
-                        Notification::make()->warning()->title('Terminal desactivada')->send();
-                    }),
+                    Action::make('deactivate')
+                        ->label('Desactivar')
+                        ->icon('heroicon-o-x-circle')
+                        ->color('danger')
+                        ->visible(fn (Terminal $record) => $record->isActive())
+                        ->requiresConfirmation()
+                        ->modalHeading('Desactivar terminal')
+                        ->modalDescription(fn (Terminal $record) => "La terminal \"{$record->name}\" dejará de aceptar marcaciones y mostrará una pantalla de fuera de servicio.")
+                        ->modalSubmitActionLabel('Sí, desactivar')
+                        ->action(function (Terminal $record) {
+                            $record->update(['status' => 'inactive']);
+                            Notification::make()->warning()->title('Terminal desactivada')->send();
+                        }),
+
+                    Action::make('generate_setup_link')
+                        ->label('Generar enlace de configuración')
+                        ->tooltip('Enlace/QR de un solo uso para vincular el dispositivo a la sincronización offline')
+                        ->icon('heroicon-o-qr-code')
+                        ->color('gray')
+                        ->modalHeading('Enlace de configuración del terminal')
+                        // La generación del token ocurre dentro del propio contenido del modal
+                        // (evaluado al abrir) en vez de mountUsing/action, para no depender de un
+                        // formulario que esta acción no tiene — ver comentario en el método.
+                        ->modalContent(fn (Terminal $record) => static::renderSetupLinkModal($record))
+                        ->modalSubmitAction(false)
+                        ->modalCancelActionLabel('Cerrar'),
+
+                    Action::make('revoke_token')
+                        ->label('Revocar token')
+                        ->tooltip('Invalida el acceso del terminal a la sincronización offline — requerirá re-provisión')
+                        ->icon('heroicon-o-shield-exclamation')
+                        ->color('danger')
+                        ->visible(fn (Terminal $record) => $record->tokens()->exists())
+                        ->requiresConfirmation()
+                        ->modalHeading('Revocar token de sincronización')
+                        ->modalDescription(fn (Terminal $record) => "El terminal \"{$record->name}\" perderá acceso a la API de sincronización offline de inmediato. Deberá re-provisionarse con un nuevo enlace de configuración antes de volver a sincronizar.")
+                        ->modalSubmitActionLabel('Sí, revocar')
+                        ->action(function (Terminal $record) {
+                            $record->revokeSyncTokens();
+                            Notification::make()
+                                ->success()
+                                ->title('Token revocado')
+                                ->body('El terminal deberá re-provisionarse para volver a sincronizar.')
+                                ->send();
+                        }),
+                ]),
             ])
             ->bulkActions([
                 BulkActionGroup::make([
@@ -352,9 +384,25 @@ class TerminalResource extends Resource
     }
 
     /**
+     * Genera un nuevo token de configuración de un solo uso para el terminal y
+     * renderiza el modal con su URL/QR. Efecto colateral intencional dentro de
+     * un closure de contenido: si Livewire re-evalúa el modal más de una vez
+     * mientras está abierto, cada llamada genera Y muestra el token vigente
+     * en ese momento de forma consistente (nunca queda desincronizado con lo
+     * que se ve en pantalla) — a costa de invalidar tokens de configuración
+     * previos no usados, lo cual es aceptable para un enlace de un solo uso.
+     */
+    protected static function renderSetupLinkModal(Terminal $record): View
+    {
+        $expiresInMinutes = 30;
+        $setupToken = $record->generateSetupToken($expiresInMinutes);
+        $url = route('terminal.setup.show', ['code' => $record->code, 'setupToken' => $setupToken]);
+
+        return view('filament.modals.terminal-setup-link', compact('url', 'expiresInMinutes'));
+    }
+
+    /**
      * Relaciones del recurso.
-     *
-     * @return array
      */
     public static function getRelations(): array
     {
@@ -363,34 +411,29 @@ class TerminalResource extends Resource
 
     /**
      * Páginas del recurso.
-     *
-     * @return array
      */
     public static function getPages(): array
     {
         return [
-            'index'  => Pages\ListTerminals::route('/'),
+            'index' => Pages\ListTerminals::route('/'),
             'create' => Pages\CreateTerminal::route('/create'),
-            'view'   => Pages\ViewTerminal::route('/{record}'),
-            'edit'   => Pages\EditTerminal::route('/{record}/edit'),
+            'view' => Pages\ViewTerminal::route('/{record}'),
+            'edit' => Pages\EditTerminal::route('/{record}/edit'),
         ];
     }
 
     /**
      * Badge de navegación: muestra el conteo de terminales inactivas.
-     *
-     * @return string|null
      */
     public static function getNavigationBadge(): ?string
     {
         $inactive = Terminal::where('status', 'inactive')->count();
+
         return $inactive > 0 ? (string) $inactive : null;
     }
 
     /**
      * Color del badge de navegación.
-     *
-     * @return string|null
      */
     public static function getNavigationBadgeColor(): ?string
     {

--- a/app/Http/Controllers/Api/TerminalEmployeeSyncController.php
+++ b/app/Http/Controllers/Api/TerminalEmployeeSyncController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Terminal;
+use App\Services\EmployeeDescriptorSyncService;
+use Carbon\Carbon;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Throwable;
+
+/**
+ * Sincronización incremental de empleados/descriptores faciales para la
+ * caché offline del kiosko. Autenticado vía Sanctum (ability `terminal:sync`).
+ */
+class TerminalEmployeeSyncController extends Controller
+{
+    public function __construct(private readonly EmployeeDescriptorSyncService $syncService) {}
+
+    /**
+     * GET /api/v1/terminal/employees/sync?since=<ISO8601>
+     *
+     * Sin `since`, retorna la carga completa (primera sincronización del kiosko).
+     * Con `since`, retorna solo los empleados modificados después de esa fecha,
+     * más los `tombstones` (empleados que dejaron de calificar) a eliminar de la caché.
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $since = null;
+
+        if ($request->filled('since')) {
+            try {
+                $since = Carbon::parse($request->query('since'));
+            } catch (Throwable) {
+                return response()->json([
+                    'ok' => false,
+                    'message' => 'Parámetro since inválido — debe ser una fecha en formato ISO 8601.',
+                ], 422);
+            }
+        }
+
+        /** @var Terminal $terminal */
+        $terminal = $request->user();
+
+        $delta = $this->syncService->deltaSince($terminal, $since);
+
+        return response()->json(array_merge(['ok' => true], $delta));
+    }
+}

--- a/app/Http/Controllers/Api/TerminalEventSyncController.php
+++ b/app/Http/Controllers/Api/TerminalEventSyncController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Terminal;
+use App\Services\AttendanceEventSyncService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * Recepción en lote de eventos de marcación de un terminal — usado tanto en
+ * línea (lote de 1) como para volcar la cola acumulada tras un período
+ * offline. Cada evento trae un `client_event_id` (UUID generado en el
+ * cliente al capturar) para deduplicar reintentos de forma segura.
+ * Autenticado vía Sanctum (ability `terminal:sync`).
+ */
+class TerminalEventSyncController extends Controller
+{
+    public function __construct(private readonly AttendanceEventSyncService $syncService) {}
+
+    public function store(Request $request): JsonResponse
+    {
+        try {
+            $data = $request->validate([
+                'events' => ['required', 'array', 'min:1', 'max:200'],
+                'events.*.client_event_id' => ['required', 'string', 'size:36'],
+                'events.*.employee_id' => ['required', 'integer'],
+                'events.*.event_type' => ['required', 'string', 'in:check_in,break_start,break_end,check_out'],
+                'events.*.recorded_at' => ['required', 'date'],
+                'events.*.location' => ['nullable', 'array'],
+                'events.*.location.lat' => ['required_with:events.*.location', 'numeric', 'between:-90,90'],
+                'events.*.location.lng' => ['required_with:events.*.location', 'numeric', 'between:-180,180'],
+            ], [
+                'events.*.client_event_id.size' => 'client_event_id debe ser un UUID (36 caracteres).',
+            ]);
+        } catch (ValidationException $e) {
+            return response()->json([
+                'ok' => false,
+                'message' => 'Datos de entrada inválidos.',
+                'errors' => $e->errors(),
+            ], 422);
+        }
+
+        /** @var Terminal $terminal */
+        $terminal = $request->user();
+
+        $results = $this->syncService->syncBatch($terminal, $data['events']);
+
+        return response()->json([
+            'ok' => true,
+            'results' => $results,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/TerminalHeartbeatController.php
+++ b/app/Http/Controllers/Api/TerminalHeartbeatController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Terminal;
+use App\Settings\GeneralSettings;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Heartbeat del terminal — se llama periódicamente mientras hay conexión
+ * (y desde el botón "Forzar sincronización") para mantener `last_seen_at`
+ * vivo y entregar la configuración vigente de reconocimiento facial, así el
+ * kiosko no depende de un sync completo de empleados para tener el umbral
+ * actualizado. Autenticado vía Sanctum (ability `terminal:sync`).
+ *
+ * Nota: en esta fase solo actualiza `last_seen_at` (ya existente). Las
+ * columnas dedicadas de heartbeat/staleness (`last_heartbeat_at`, etc.) y su
+ * UI en Filament se agregan en una fase posterior del rollout offline.
+ */
+class TerminalHeartbeatController extends Controller
+{
+    public function store(Request $request, GeneralSettings $settings): JsonResponse
+    {
+        /** @var Terminal $terminal */
+        $terminal = $request->user();
+
+        $terminal->update(['last_seen_at' => now()]);
+
+        return response()->json([
+            'ok' => true,
+            'server_time' => now()->toIso8601String(),
+            'config' => [
+                'face_threshold' => (float) $settings->face_threshold,
+                'face_min_confidence_gap' => (float) $settings->face_min_confidence_gap,
+            ],
+        ]);
+    }
+}

--- a/app/Http/Controllers/AttendanceFaceMarkController.php
+++ b/app/Http/Controllers/AttendanceFaceMarkController.php
@@ -8,13 +8,16 @@ use App\Models\AttendanceMarkFailure;
 use App\Models\Employee;
 use App\Models\Terminal;
 use App\Rules\FaceDescriptor;
+use App\Settings\GeneralSettings;
 use Carbon\Carbon;
 use Illuminate\Contracts\View\View as ViewContract;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Validation\ValidationException;
 use JsonException;
 use Throwable;
@@ -111,7 +114,7 @@ class AttendanceFaceMarkController extends Controller
 
         try {
             // CORRECCIÓN 4: Validar que el threshold sea válido
-            $threshold = (float) app(\App\Settings\GeneralSettings::class)->face_threshold;
+            $threshold = (float) app(GeneralSettings::class)->face_threshold;
             if ($threshold <= 0 || $threshold > 2.0) {
                 Log::warning("Umbral de reconocimiento facial inválido ({$threshold}), usando valor por defecto 0.45", ['threshold' => $threshold]);
                 $threshold = 0.45; // valor por defecto seguro
@@ -166,7 +169,7 @@ class AttendanceFaceMarkController extends Controller
             $allowed = $this->allowedNextEvents($last?->event_type);
 
             $photoUrl = $employee->photo
-                ? \Illuminate\Support\Facades\Storage::url($employee->photo)
+                ? Storage::url($employee->photo)
                 : url('/images/default-avatar.png');
 
             return response()->json([
@@ -234,7 +237,7 @@ class AttendanceFaceMarkController extends Controller
                 ->where('id', $data['employee_id'])
                 ->where('status', 'active')
                 ->firstOrFail();
-        } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
+        } catch (ModelNotFoundException $e) {
             Log::warning("Marcación fallida: empleado ID {$data['employee_id']} no encontrado o inactivo", [
                 'employee_id' => $data['employee_id'],
                 'ip' => $request->ip(),
@@ -558,7 +561,7 @@ class AttendanceFaceMarkController extends Controller
             }
 
             // Obtener gap mínimo de configuración
-            $minGap = (float) app(\App\Settings\GeneralSettings::class)->face_min_confidence_gap;
+            $minGap = (float) app(GeneralSettings::class)->face_min_confidence_gap;
 
             $identifiedLabel = $best ? "CI {$best->ci} {$best->first_name} {$best->last_name}" : 'ninguno';
             Log::info("Identificación facial: {$processedCount} candidatos procesados — resultado: {$identifiedLabel}", [
@@ -656,7 +659,11 @@ class AttendanceFaceMarkController extends Controller
         return $distance;
     }
 
-    /** Reglas de transición válidas */
+    /**
+     * Reglas de transición válidas — delega a AttendanceEvent::allowedNextEventTypes(),
+     * compartida con AttendanceEventSyncService (sync de terminales offline) para no
+     * duplicar la máquina de estados en dos lugares.
+     */
     protected function allowedNextEvents(?string $last): array
     {
         // CORRECCIÓN 20: Validar tipos de eventos conocidos
@@ -668,17 +675,7 @@ class AttendanceFaceMarkController extends Controller
             return ['check_in']; // Fallback seguro
         }
 
-        if ($last === null) {
-            return ['check_in'];
-        }
-
-        return match ($last) {
-            'check_in' => ['break_start', 'check_out'],
-            'break_start' => ['break_end'],
-            'break_end' => ['break_start', 'check_out'],
-            'check_out' => [], // ya terminó el día
-            default => ['check_in'], // fallback seguro
-        };
+        return AttendanceEvent::allowedNextEventTypes($last);
     }
 
     /** Traducciones de tipos de eventos a español */
@@ -728,7 +725,7 @@ class AttendanceFaceMarkController extends Controller
                 'ip_address' => $request->ip(),
                 'location' => $location,
             ]);
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             // No interrumpir el flujo principal si falla el registro del error
             Log::error('No se pudo persistir el fallo de marcación', [
                 'failure_type' => $failureType,

--- a/app/Http/Controllers/TerminalSetupController.php
+++ b/app/Http/Controllers/TerminalSetupController.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Terminal;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Illuminate\View\View;
+
+/**
+ * Provisión de terminales para la marcación offline vía PWA. El admin genera
+ * un enlace de configuración de un solo uso desde TerminalResource; el
+ * kiosko lo visita una vez, online, durante la instalación física, y recibe
+ * a cambio un token Sanctum (ability `terminal:sync`) que usará contra
+ * routes/api.php de ahí en adelante — incluso tras largos períodos offline,
+ * ya que no depende de la sesión de Laravel (que expira a los 120 minutos).
+ */
+class TerminalSetupController extends Controller
+{
+    /** Muestra la pantalla de vinculación del terminal. */
+    public function show(string $code, string $setupToken): View
+    {
+        $terminal = Terminal::where('code', $code)->first();
+
+        if (! $terminal || ! $terminal->isSetupTokenValid($setupToken)) {
+            return view('attendances.terminal-setup-invalid');
+        }
+
+        return view('attendances.terminal-setup', compact('terminal', 'setupToken'));
+    }
+
+    /** Reclama el enlace y emite el token Sanctum del terminal. Un solo uso. */
+    public function claim(Request $request, string $code, string $setupToken): JsonResponse
+    {
+        $terminal = Terminal::where('code', $code)->first();
+
+        if (! $terminal || ! $terminal->isSetupTokenValid($setupToken)) {
+            Log::warning("Intento de reclamo de setup token inválido o expirado para terminal '{$code}'", [
+                'code' => $code,
+                'ip' => $request->ip(),
+            ]);
+
+            return response()->json([
+                'ok' => false,
+                'message' => 'Enlace de configuración inválido o expirado. Solicite uno nuevo desde el panel de administración.',
+            ], 422);
+        }
+
+        $plainTextToken = $terminal->claimSanctumToken();
+
+        Log::info("Terminal '{$terminal->code}' ({$terminal->name}) provisionado para sincronización offline", [
+            'terminal_id' => $terminal->id,
+            'branch_id' => $terminal->branch_id,
+        ]);
+
+        return response()->json([
+            'ok' => true,
+            'token' => $plainTextToken,
+            'terminal' => [
+                'id' => $terminal->id,
+                'code' => $terminal->code,
+                'name' => $terminal->name,
+                'branch_id' => $terminal->branch_id,
+            ],
+        ]);
+    }
+}

--- a/app/Models/AttendanceEvent.php
+++ b/app/Models/AttendanceEvent.php
@@ -2,19 +2,21 @@
 
 namespace App\Models;
 
+use Database\Factories\AttendanceFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class AttendanceEvent extends Model
 {
-    /** @use HasFactory<\Database\Factories\AttendanceFactory> */
+    /** @use HasFactory<AttendanceFactory> */
     use HasFactory;
 
     protected $fillable = [
         'attendance_day_id',
         'event_type',
         'recorded_at',
+        'synced_at',
         'source',
         'location',
         'employee_id',
@@ -24,12 +26,14 @@ class AttendanceEvent extends Model
         'branch_name',
         'terminal_id',
         'branch_mismatch',
+        'client_event_id',
     ];
 
     protected $casts = [
-        'recorded_at'    => 'datetime',
-        'location'       => 'array',
-        'branch_mismatch'=> 'boolean',
+        'recorded_at' => 'datetime',
+        'synced_at' => 'datetime',
+        'location' => 'array',
+        'branch_mismatch' => 'boolean',
     ];
 
     /**
@@ -68,7 +72,7 @@ class AttendanceEvent extends Model
      */
     public function getLocationDisplayAttribute(): string
     {
-        if (!$this->location) {
+        if (! $this->location) {
             return 'Sin ubicación';
         }
 
@@ -83,7 +87,7 @@ class AttendanceEvent extends Model
 
             if (is_array($this->location)) {
                 return collect($this->location)
-                    ->map(fn($value, $key) => "{$key}: {$value}")
+                    ->map(fn ($value, $key) => "{$key}: {$value}")
                     ->join(', ');
             }
 
@@ -98,7 +102,7 @@ class AttendanceEvent extends Model
      */
     public function getGoogleMapsUrlAttribute(): ?string
     {
-        if (!$this->location || !is_array($this->location)) {
+        if (! $this->location || ! is_array($this->location)) {
             return null;
         }
 
@@ -182,8 +186,8 @@ class AttendanceEvent extends Model
     {
         return [
             'terminal' => 'Terminal (kiosco)',
-            'mobile'   => 'Móvil',
-            'manual'   => 'Manual (admin)',
+            'mobile' => 'Móvil',
+            'manual' => 'Manual (admin)',
         ];
     }
 
@@ -194,9 +198,9 @@ class AttendanceEvent extends Model
     {
         return match ($source) {
             'terminal' => 'Terminal',
-            'mobile'   => 'Móvil',
-            'manual'   => 'Manual',
-            default    => 'Desconocido',
+            'mobile' => 'Móvil',
+            'manual' => 'Manual',
+            default => 'Desconocido',
         };
     }
 
@@ -207,9 +211,9 @@ class AttendanceEvent extends Model
     {
         return match ($source) {
             'terminal' => 'info',
-            'mobile'   => 'success',
-            'manual'   => 'warning',
-            default    => 'gray',
+            'mobile' => 'success',
+            'manual' => 'warning',
+            default => 'gray',
         };
     }
 
@@ -220,9 +224,30 @@ class AttendanceEvent extends Model
     {
         return match ($source) {
             'terminal' => 'heroicon-o-computer-desktop',
-            'mobile'   => 'heroicon-o-device-phone-mobile',
-            'manual'   => 'heroicon-o-pencil-square',
-            default    => 'heroicon-o-question-mark-circle',
+            'mobile' => 'heroicon-o-device-phone-mobile',
+            'manual' => 'heroicon-o-pencil-square',
+            default => 'heroicon-o-question-mark-circle',
+        };
+    }
+
+    /**
+     * Máquina de estados de marcación diaria: dado el último evento del día,
+     * retorna qué tipos de evento son válidos a continuación. Compartida por
+     * el flujo de marcación en línea (AttendanceFaceMarkController::store())
+     * y el flujo de sincronización de terminales offline (AttendanceEventSyncService)
+     * para no duplicar la regla de negocio en dos lugares.
+     *
+     * @return array<int, string>
+     */
+    public static function allowedNextEventTypes(?string $last): array
+    {
+        return match ($last) {
+            null => ['check_in'],
+            'check_in' => ['break_start', 'check_out'],
+            'break_start' => ['break_end'],
+            'break_end' => ['break_start', 'check_out'],
+            'check_out' => [],
+            default => ['check_in'],
         };
     }
 
@@ -241,7 +266,7 @@ class AttendanceEvent extends Model
      */
     public function getFormattedLocation(): string
     {
-        if (!$this->hasValidLocation()) {
+        if (! $this->hasValidLocation()) {
             return 'Sin ubicación';
         }
 
@@ -265,7 +290,7 @@ class AttendanceEvent extends Model
      */
     public function getLocationTooltip(): string
     {
-        if (!$this->hasValidLocation()) {
+        if (! $this->hasValidLocation()) {
             return 'No hay datos de ubicación';
         }
 

--- a/app/Models/Terminal.php
+++ b/app/Models/Terminal.php
@@ -5,11 +5,24 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
+use Laravel\Sanctum\HasApiTokens;
 
-/** Representa un dispositivo físico de marcación de asistencia en una sucursal. */
+/**
+ * Representa un dispositivo físico de marcación de asistencia en una sucursal.
+ *
+ * Puede autenticarse contra la API de sincronización offline (ver routes/api.php)
+ * mediante un token Sanctum con ability `terminal:sync`, emitido al reclamar un
+ * enlace de configuración (setup_token) generado desde TerminalResource.
+ */
 class Terminal extends Model
 {
+    use HasApiTokens;
+
+    /** Ability Sanctum requerida para consumir la API de sincronización de terminales. */
+    public const SYNC_ABILITY = 'terminal:sync';
+
     protected $fillable = [
         'name',
         'code',
@@ -23,11 +36,18 @@ class Terminal extends Model
         'installed_at',
         'installed_by_id',
         'last_seen_at',
+        'setup_token',
+        'setup_token_expires_at',
+    ];
+
+    protected $hidden = [
+        'setup_token',
     ];
 
     protected $casts = [
         'installed_at' => 'date',
         'last_seen_at' => 'datetime',
+        'setup_token_expires_at' => 'datetime',
     ];
 
     // =========================================================================
@@ -78,7 +98,7 @@ class Terminal extends Model
     public static function getStatusOptions(): array
     {
         return [
-            'active'   => 'Activa',
+            'active' => 'Activa',
             'inactive' => 'Inactiva',
         ];
     }
@@ -91,7 +111,7 @@ class Terminal extends Model
     public static function getStatusLabels(): array
     {
         return [
-            'active'   => 'Activa',
+            'active' => 'Activa',
             'inactive' => 'Inactiva',
         ];
     }
@@ -104,7 +124,7 @@ class Terminal extends Model
     public static function getStatusColors(): array
     {
         return [
-            'active'   => 'success',
+            'active' => 'success',
             'inactive' => 'danger',
         ];
     }
@@ -131,8 +151,6 @@ class Terminal extends Model
 
     /**
      * Retorna la URL pública de la terminal.
-     *
-     * @return string
      */
     public function getUrlAttribute(): string
     {
@@ -141,12 +159,11 @@ class Terminal extends Model
 
     /**
      * Descripción del dispositivo (marca + modelo).
-     *
-     * @return string|null
      */
     public function getDeviceDescriptionAttribute(): ?string
     {
         $parts = array_filter([$this->device_brand, $this->device_model]);
+
         return $parts ? implode(' ', $parts) : null;
     }
 
@@ -156,8 +173,6 @@ class Terminal extends Model
 
     /**
      * Genera un código alfanumérico único de 8 caracteres para la terminal.
-     *
-     * @return string
      */
     public static function generateUniqueCode(): string
     {
@@ -166,5 +181,63 @@ class Terminal extends Model
         } while (static::where('code', $code)->exists());
 
         return $code;
+    }
+
+    // =========================================================================
+    // PROVISIÓN — TOKEN DE CONFIGURACIÓN Y TOKEN SANCTUM
+    // =========================================================================
+
+    /**
+     * Genera un token de configuración de un solo uso (para el enlace/QR de
+     * provisión) y lo persiste con expiración corta. Invalida cualquier
+     * enlace de configuración previo sin consumir.
+     *
+     * @param  int  $expiresInMinutes  Vigencia del enlace, en minutos.
+     * @return string El token plano a incluir en la URL de configuración.
+     */
+    public function generateSetupToken(int $expiresInMinutes = 30): string
+    {
+        $token = Str::random(40);
+
+        $this->forceFill([
+            'setup_token' => $token,
+            'setup_token_expires_at' => now()->addMinutes($expiresInMinutes),
+        ])->save();
+
+        return $token;
+    }
+
+    /** Indica si el token de configuración recibido es válido (existe, coincide y no expiró). */
+    public function isSetupTokenValid(string $token): bool
+    {
+        return $this->setup_token !== null
+            && hash_equals($this->setup_token, $token)
+            && $this->setup_token_expires_at instanceof Carbon
+            && $this->setup_token_expires_at->isFuture();
+    }
+
+    /**
+     * Consume el token de configuración (single-use) y emite un token Sanctum
+     * con la ability de sincronización. Revoca tokens `terminal:sync`
+     * previos para que solo quede uno activo por terminal.
+     *
+     * @return string Token Sanctum en texto plano — solo se retorna una vez, nunca se persiste en claro.
+     */
+    public function claimSanctumToken(): string
+    {
+        $this->tokens()->where('name', 'like', 'kiosk:%')->delete();
+
+        $this->forceFill([
+            'setup_token' => null,
+            'setup_token_expires_at' => null,
+        ])->save();
+
+        return $this->createToken('kiosk:'.$this->code, [self::SYNC_ABILITY])->plainTextToken;
+    }
+
+    /** Revoca todos los tokens Sanctum activos del terminal (fuerza re-provisión). */
+    public function revokeSyncTokens(): void
+    {
+        $this->tokens()->delete();
     }
 }

--- a/app/Services/AttendanceEventSyncService.php
+++ b/app/Services/AttendanceEventSyncService.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\AttendanceDay;
+use App\Models\AttendanceEvent;
+use App\Models\Employee;
+use App\Models\Terminal;
+use Carbon\Carbon;
+use Illuminate\Database\UniqueConstraintViolationException;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Sincroniza en lote los eventos de marcación capturados por un terminal
+ * (online o acumulados mientras estuvo offline), de forma idempotente vía
+ * `client_event_id`. Reutiliza la misma máquina de estados que valida
+ * AttendanceFaceMarkController::store() — ver AttendanceEvent::allowedNextEventTypes().
+ *
+ * A diferencia del flujo de marcación en línea (un evento por request, el
+ * cliente ya sabe el estado actual porque acaba de consultarlo), acá el
+ * terminal puede haber estado offline y traer varios eventos represados,
+ * potencialmente en conflicto con lo que el servidor ya registró desde otro
+ * origen mientras tanto. Por eso cada evento se re-valida contra el estado
+ * *actual* del servidor en el momento de sincronizar, no contra lo que el
+ * terminal creía que era el estado al capturar.
+ */
+class AttendanceEventSyncService
+{
+    /**
+     * @param  array<int, array{client_event_id: string, employee_id: int, event_type: string, recorded_at: string, location?: array|null}>  $events
+     * @return array<int, array{client_event_id: string, status: string, event_id?: int, conflict_reason?: string, message?: string}>
+     */
+    public function syncBatch(Terminal $terminal, array $events): array
+    {
+        $results = [];
+
+        $employeeIds = collect($events)->pluck('employee_id')->unique();
+        $employees = Employee::query()
+            ->whereIn('id', $employeeIds)
+            ->where('status', 'active')
+            ->get()
+            ->keyBy('id');
+
+        // Se procesa por empleado, en orden cronológico de captura, para que un lote
+        // con varios eventos represados del mismo empleado se replaye en el orden en
+        // que realmente ocurrieron (no en el orden de llegada del array).
+        $byEmployee = collect($events)->groupBy('employee_id');
+
+        foreach ($byEmployee as $employeeId => $employeeEvents) {
+            $employee = $employees->get($employeeId);
+            $ordered = $employeeEvents->sortBy('recorded_at')->values();
+
+            foreach ($ordered as $eventData) {
+                $results[] = $this->syncOne($terminal, $employee, $eventData);
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * @param  array{client_event_id: string, employee_id: int, event_type: string, recorded_at: string, location?: array|null}  $eventData
+     * @return array{client_event_id: string, status: string, event_id?: int, conflict_reason?: string, message?: string}
+     */
+    private function syncOne(Terminal $terminal, ?Employee $employee, array $eventData): array
+    {
+        $clientEventId = $eventData['client_event_id'];
+
+        if (! $employee) {
+            return [
+                'client_event_id' => $clientEventId,
+                'status' => 'rejected',
+                'conflict_reason' => 'employee_not_found',
+                'message' => 'Empleado no encontrado o inactivo.',
+            ];
+        }
+
+        // Idempotencia: reintentar el mismo lote (ej. la respuesta anterior se perdió
+        // en el camino) no debe duplicar el evento ya sincronizado.
+        $existing = AttendanceEvent::where('client_event_id', $clientEventId)->first();
+        if ($existing) {
+            return [
+                'client_event_id' => $clientEventId,
+                'status' => 'duplicate',
+                'event_id' => $existing->id,
+            ];
+        }
+
+        try {
+            $recordedAt = Carbon::parse($eventData['recorded_at']);
+        } catch (Throwable) {
+            return [
+                'client_event_id' => $clientEventId,
+                'status' => 'rejected',
+                'conflict_reason' => 'invalid_timestamp',
+                'message' => 'Fecha/hora de marcación inválida.',
+            ];
+        }
+
+        $date = $recordedAt->copy()->timezone(config('app.timezone'))->toDateString();
+
+        try {
+            return DB::transaction(fn () => $this->insertEvent($terminal, $employee, $eventData, $clientEventId, $recordedAt, $date));
+        } catch (UniqueConstraintViolationException) {
+            // Carrera entre dos sync concurrentes con el mismo client_event_id — el otro ganó, tratar como duplicado.
+            $existing = AttendanceEvent::where('client_event_id', $clientEventId)->first();
+
+            return [
+                'client_event_id' => $clientEventId,
+                'status' => $existing ? 'duplicate' : 'rejected',
+                'event_id' => $existing?->id,
+            ];
+        }
+    }
+
+    /**
+     * @param  array{client_event_id: string, employee_id: int, event_type: string, recorded_at: string, location?: array|null}  $eventData
+     * @return array{client_event_id: string, status: string, event_id?: int, conflict_reason?: string, message?: string}
+     */
+    private function insertEvent(
+        Terminal $terminal,
+        Employee $employee,
+        array $eventData,
+        string $clientEventId,
+        Carbon $recordedAt,
+        string $date,
+    ): array {
+        $day = AttendanceDay::firstOrCreate(
+            ['employee_id' => $employee->id, 'date' => $date],
+            ['status' => 'present']
+        );
+
+        $last = AttendanceEvent::where('attendance_day_id', $day->id)
+            ->lockForUpdate()
+            ->latest('recorded_at')
+            ->first();
+
+        $allowed = AttendanceEvent::allowedNextEventTypes($last?->event_type);
+
+        if (! in_array($eventData['event_type'], $allowed, true)) {
+            Log::warning("Sync de terminal — evento '{$eventData['event_type']}' ya no es válido para el empleado {$employee->id} (último registrado: ".($last->event_type ?? 'ninguno').')', [
+                'terminal_id' => $terminal->id,
+                'client_event_id' => $clientEventId,
+                'employee_id' => $employee->id,
+                'attempted_event' => $eventData['event_type'],
+                'last_event' => $last?->event_type,
+                'allowed_events' => $allowed,
+            ]);
+
+            return [
+                'client_event_id' => $clientEventId,
+                'status' => 'conflict',
+                'conflict_reason' => 'invalid_sequence',
+                'message' => 'La secuencia de marcación ya no es válida en el servidor — probablemente otro origen registró un evento mientras el terminal estaba offline.',
+            ];
+        }
+
+        if ($day->status !== 'present') {
+            $day->update(['status' => 'present']);
+        }
+
+        $branchMismatch = $terminal->branch_id
+            && $employee->branch_id
+            && $terminal->branch_id !== $employee->branch_id;
+
+        $event = $day->events()->create([
+            'client_event_id' => $clientEventId,
+            'event_type' => $eventData['event_type'],
+            'recorded_at' => $recordedAt,
+            'synced_at' => now(),
+            'source' => 'terminal',
+            'location' => $eventData['location'] ?? null,
+            'terminal_id' => $terminal->id,
+            'branch_mismatch' => $branchMismatch,
+        ]);
+
+        return [
+            'client_event_id' => $clientEventId,
+            'status' => 'synced',
+            'event_id' => $event->id,
+        ];
+    }
+}

--- a/app/Services/EmployeeDescriptorSyncService.php
+++ b/app/Services/EmployeeDescriptorSyncService.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Employee;
+use App\Models\Terminal;
+use Carbon\Carbon;
+
+/**
+ * Sincronización incremental (delta) de descriptores faciales de empleados
+ * activos, scopeada por la sucursal del terminal — alimenta la caché offline
+ * del kiosko (IndexedDB) para que el reconocimiento facial pueda correr
+ * localmente sin conexión.
+ */
+class EmployeeDescriptorSyncService
+{
+    /**
+     * @return array{
+     *     employees: array<int, array{id: int, first_name: string, last_name: string, ci: string|null, face_descriptor: array}>,
+     *     tombstones: array<int, int>,
+     *     server_time: string,
+     *     sync_version: string,
+     * }
+     */
+    public function deltaSince(Terminal $terminal, ?Carbon $since): array
+    {
+        // Se toma antes de consultar para que el próximo `since` del cliente nunca
+        // quede por delante de datos que todavía no vio (mejor repetir de más que perder cambios).
+        $queryStartedAt = now();
+
+        $employees = Employee::query()
+            ->where('branch_id', $terminal->branch_id)
+            ->where('status', 'active')
+            ->whereNotNull('face_descriptor')
+            ->when($since, fn ($query) => $query->where('updated_at', '>', $since))
+            ->select(['id', 'first_name', 'last_name', 'ci', 'face_descriptor'])
+            ->get();
+
+        return [
+            'employees' => $employees->map(fn (Employee $employee) => [
+                'id' => $employee->id,
+                'first_name' => $employee->first_name,
+                'last_name' => $employee->last_name,
+                'ci' => $employee->ci,
+                'face_descriptor' => $employee->face_descriptor,
+            ])->values()->all(),
+            'tombstones' => $since ? $this->tombstonesSince($terminal, $since) : [],
+            'server_time' => now()->toIso8601String(),
+            'sync_version' => $queryStartedAt->toIso8601String(),
+        ];
+    }
+
+    /**
+     * IDs de empleados de esta sucursal que cambiaron desde `$since` y ya no
+     * califican para la caché offline (se desactivaron o perdieron su
+     * descriptor) — el kiosko debe eliminarlos de su copia local.
+     *
+     * Limitación conocida: si un empleado se movió a OTRA sucursal, esta
+     * consulta no lo detecta porque ya no aparece con branch_id = la
+     * sucursal del terminal. Un cambio de sucursal es infrecuente y, en el
+     * peor caso, deja un descriptor obsoleto en la caché del kiosko viejo
+     * hasta la próxima re-provisión — no un problema de seguridad (el
+     * descriptor ya era visible para ese kiosko), solo de limpieza.
+     *
+     * @return array<int, int>
+     */
+    private function tombstonesSince(Terminal $terminal, Carbon $since): array
+    {
+        return Employee::query()
+            ->where('branch_id', $terminal->branch_id)
+            ->where('updated_at', '>', $since)
+            ->where(function ($query) {
+                $query->where('status', '!=', 'active')->orWhereNull('face_descriptor');
+            })
+            ->pluck('id')
+            ->all();
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,15 +3,23 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Laravel\Sanctum\Http\Middleware\CheckAbilities;
+use Laravel\Sanctum\Http\Middleware\CheckForAnyAbility;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->redirectGuestsTo(fn () => route('filament.admin.auth.login'));
+
+        $middleware->alias([
+            'abilities' => CheckAbilities::class,
+            'ability' => CheckForAnyAbility::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "filament/filament": "^3.3",
         "filament/spatie-laravel-settings-plugin": "^3.2",
         "laravel/framework": "^12.0",
+        "laravel/sanctum": "^4.3",
         "laravel/tinker": "^2.10.1",
         "maatwebsite/excel": "^3.1",
         "owen-it/laravel-auditing": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "902627940aa7a3c8d6926bf4885dce32",
+    "content-hash": "1c9b1edf456ca4d0067c95bc2bf5cdda",
     "packages": [
         {
             "name": "achyutn/filament-log-viewer",
@@ -3357,6 +3357,69 @@
                 "source": "https://github.com/laravel/prompts/tree/v0.3.21"
             },
             "time": "2026-06-26T00:11:25+00:00"
+        },
+        {
+            "name": "laravel/sanctum",
+            "version": "v4.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/sanctum.git",
+                "reference": "fee27a573d1a013af3721d86153a65e0b11927e6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/sanctum/zipball/fee27a573d1a013af3721d86153a65e0b11927e6",
+                "reference": "fee27a573d1a013af3721d86153a65e0b11927e6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "illuminate/console": "^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^11.0|^12.0|^13.0",
+                "illuminate/database": "^11.0|^12.0|^13.0",
+                "illuminate/support": "^11.0|^12.0|^13.0",
+                "php": "^8.2",
+                "symfony/console": "^7.0|^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.6",
+                "orchestra/testbench": "^9.15|^10.8|^11.0",
+                "phpstan/phpstan": "^1.10"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Sanctum\\SanctumServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Sanctum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Laravel Sanctum provides a featherweight authentication system for SPAs and simple APIs.",
+            "keywords": [
+                "auth",
+                "laravel",
+                "sanctum"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/sanctum/issues",
+                "source": "https://github.com/laravel/sanctum"
+            },
+            "time": "2026-06-23T18:26:55+00:00"
         },
         {
             "name": "laravel/serializable-closure",
@@ -13861,5 +13924,5 @@
         "php": "^8.2"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -1,0 +1,87 @@
+<?php
+
+use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Foundation\Http\Middleware\ValidateCsrfToken;
+use Laravel\Sanctum\Http\Middleware\AuthenticateSession;
+use Laravel\Sanctum\Sanctum;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Stateful Domains
+    |--------------------------------------------------------------------------
+    |
+    | Requests from the following domains / hosts will receive stateful API
+    | authentication cookies. Typically, these should include your local
+    | and production domains which access your API via a frontend SPA.
+    |
+    */
+
+    'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
+        '%s%s',
+        'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
+        Sanctum::currentApplicationUrlWithPort(),
+        // Sanctum::currentRequestHost(),
+    ))),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Sanctum Guards
+    |--------------------------------------------------------------------------
+    |
+    | This array contains the authentication guards that will be checked when
+    | Sanctum is trying to authenticate a request. If none of these guards
+    | are able to authenticate the request, Sanctum will use the bearer
+    | token that's present on an incoming request for authentication.
+    |
+    */
+
+    'guard' => ['web'],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Expiration Minutes
+    |--------------------------------------------------------------------------
+    |
+    | This value controls the number of minutes until an issued token will be
+    | considered expired. This will override any values set in the token's
+    | "expires_at" attribute, but first-party sessions are not affected.
+    |
+    */
+
+    'expiration' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Token Prefix
+    |--------------------------------------------------------------------------
+    |
+    | Sanctum can prefix new tokens in order to take advantage of numerous
+    | security scanning initiatives maintained by open source platforms
+    | that notify developers if they commit tokens into repositories.
+    |
+    | See: https://docs.github.com/en/code-security/secret-scanning/about-secret-scanning
+    |
+    */
+
+    'token_prefix' => env('SANCTUM_TOKEN_PREFIX', ''),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Sanctum Middleware
+    |--------------------------------------------------------------------------
+    |
+    | When authenticating your first-party SPA with Sanctum you may need to
+    | customize some of the middleware Sanctum uses while processing the
+    | request. You may change the middleware listed below as required.
+    |
+    */
+
+    'middleware' => [
+        'authenticate_session' => AuthenticateSession::class,
+        'encrypt_cookies' => EncryptCookies::class,
+        'validate_csrf_token' => ValidateCsrfToken::class,
+    ],
+
+];

--- a/database/migrations/2026_08_18_220929_create_personal_access_tokens_table.php
+++ b/database/migrations/2026_08_18_220929_create_personal_access_tokens_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('tokenable');
+            $table->text('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable()->index();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('personal_access_tokens');
+    }
+};

--- a/database/migrations/2026_08_18_221031_add_offline_sync_fields_to_attendance_events_table.php
+++ b/database/migrations/2026_08_18_221031_add_offline_sync_fields_to_attendance_events_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Agrega client_event_id y synced_at para el flujo de sincronización de
+ * terminales (kiosko offline vía PWA, ver AttendanceEventSyncController).
+ *
+ * - client_event_id: UUID generado en el cliente al momento de la captura
+ *   (no al sincronizar), usado para deduplicar reintentos con seguridad.
+ * - synced_at: null para eventos registrados en línea en tiempo real;
+ *   poblado cuando el evento llegó a través del flujo de sincronización
+ *   offline, para poder distinguir "marcado en vivo" de "marcado offline,
+ *   sincronizado después" en reportes y exports.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('attendance_events', function (Blueprint $table) {
+            $table->string('client_event_id', 36)
+                ->nullable()
+                ->unique()
+                ->after('id')
+                ->comment('UUID generado en el cliente al capturar — deduplica reintentos de sync');
+
+            $table->timestamp('synced_at')
+                ->nullable()
+                ->after('recorded_at')
+                ->comment('Momento en que el evento fue recibido vía sync offline (null = registrado en línea)');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('attendance_events', function (Blueprint $table) {
+            $table->dropColumn(['client_event_id', 'synced_at']);
+        });
+    }
+};

--- a/database/migrations/2026_08_18_221031_add_setup_token_to_terminals_table.php
+++ b/database/migrations/2026_08_18_221031_add_setup_token_to_terminals_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Agrega el token de configuración de un solo uso usado para provisionar el
+ * terminal como PWA offline: el admin genera el enlace desde Filament, el
+ * terminal lo visita una vez (online) para reclamar su token Sanctum, y el
+ * setup_token queda invalidado inmediatamente después.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('terminals', function (Blueprint $table) {
+            $table->string('setup_token', 64)
+                ->nullable()
+                ->unique()
+                ->after('last_seen_at')
+                ->comment('Token de un solo uso para reclamar el token Sanctum del terminal');
+
+            $table->timestamp('setup_token_expires_at')
+                ->nullable()
+                ->after('setup_token');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('terminals', function (Blueprint $table) {
+            $table->dropColumn(['setup_token', 'setup_token_expires_at']);
+        });
+    }
+};

--- a/resources/js/attendances/mark.js
+++ b/resources/js/attendances/mark.js
@@ -1,4 +1,5 @@
 import L from 'leaflet';
+import { captureFaceSamples } from '../shared/face-capture-core.js';
 
 /**
  * =============================================================================
@@ -953,7 +954,17 @@ const statusBar           = document.getElementById("statusBar");
                             height: video.videoHeight,
                         });
 
-                        if (faceInFrameState !== "found") {
+                        // Feedback inmediato si la cara está muy chica — evita que el usuario
+                        // espere todo el ciclo de captura (5 muestras) para enterarse recién al fallar
+                        const box = detection.detection.box;
+                        if (box.width < MIN_FACE_SIZE || box.height < MIN_FACE_SIZE) {
+                            if (faceInFrameState !== "small") {
+                                faceInFrameState = "small";
+                                cancelAutoIdentifyDwell();
+                                setVideoState("detecting");
+                                setStatusBar("Acérquese un poco más a la cámara", "detecting");
+                            }
+                        } else if (faceInFrameState !== "found") {
                             faceInFrameState = "found";
                             setVideoState("face-found");
                             setStatusBar("Quédate quieto...", "found");
@@ -993,40 +1004,20 @@ const statusBar           = document.getElementById("statusBar");
      * @returns {Promise<number[]>} Array de 128 números representando el descriptor facial promediado
      */
     async function captureDescriptor(samples = 5, intervalMs = 150, onProgress = null) {
-        const descriptors = [];
-
-        for (let i = 0; i < samples; i++) {
-            try {
-                const det = await faceapi
-                    .detectSingleFace(video, tinyOptions)
-                    .withFaceLandmarks()
-                    .withFaceDescriptor();
-
-                if (det?.descriptor) {
-                    const box = det.detection.box;
-                    if (box.width >= MIN_FACE_SIZE && box.height >= MIN_FACE_SIZE) {
-                        descriptors.push(Array.from(det.descriptor));
-                        if (onProgress) onProgress(descriptors.length);
-                    } else {
-                        logWarn(`Rostro muy pequeño: ${Math.round(box.width)}x${Math.round(box.height)}px (mínimo ${MIN_FACE_SIZE}px)`);
-                    }
+        const { averaged } = await captureFaceSamples(video, tinyOptions, {
+            samples,
+            intervalMs,
+            minFaceSize: MIN_FACE_SIZE,
+            minRequired: 3,
+            onProgress,
+            onRejectedSample: (reason, detail) => {
+                if (reason === 'too_small') {
+                    logWarn(`Rostro muy pequeño: ${Math.round(detail.width)}x${Math.round(detail.height)}px (mínimo ${MIN_FACE_SIZE}px)`);
+                } else if (reason === 'error') {
+                    logWarn('Error capturando muestra:', detail);
                 }
-            } catch (error) {
-                logWarn(`Error capturando muestra ${i + 1}:`, error);
-            }
-            if (i < samples - 1) await sleep(intervalMs);
-        }
-
-        if (descriptors.length < 3) {
-            throw new Error(`Solo se capturaron ${descriptors.length} muestras válidas (mínimo 3). Acerque el rostro a la cámara.`);
-        }
-
-        const averaged = new Array(128).fill(0);
-        for (let i = 0; i < 128; i++) {
-            let sum = 0;
-            for (const desc of descriptors) sum += desc[i];
-            averaged[i] = sum / descriptors.length;
-        }
+            },
+        });
         return averaged;
     }
 
@@ -1341,8 +1332,9 @@ const statusBar           = document.getElementById("statusBar");
                 return;
             }
             const detailed = buildDetailedError(e.message);
-            // Cooldown de 3s: drawLoop no actualiza estado visual ni se inicia nuevo dwell
-            notRecognizedUntil = Date.now() + 3000;
+            // Cooldown breve: drawLoop no actualiza estado visual ni se inicia nuevo dwell.
+            // Reducido de 3s a 1.5s — el modal de error ya frena al usuario, no hace falta duplicar la espera.
+            notRecognizedUntil = Date.now() + 1500;
             setVideoState("error");
             setStatusBar("No se pudo identificar", "error");
             await finishCaptureProgress("error");

--- a/resources/js/attendances/terminal.js
+++ b/resources/js/attendances/terminal.js
@@ -1,3 +1,5 @@
+import { captureFaceSamples } from '../shared/face-capture-core.js';
+
 document.addEventListener("DOMContentLoaded", () => {
     // ============================================================================
     // ELEMENTOS DEL DOM
@@ -106,6 +108,9 @@ document.addEventListener("DOMContentLoaded", () => {
 
     const tinyOptions  = new faceapi.TinyFaceDetectorOptions({ inputSize: 416, scoreThreshold: 0.6 });
     const lightOptions = new faceapi.TinyFaceDetectorOptions({ inputSize: 160, scoreThreshold: 0.5 });
+
+    /** Tamaño mínimo de rostro en píxeles para aceptar una detección (drawLoop y captureDescriptor) */
+    const MIN_FACE_SIZE = 100;
 
     const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
@@ -529,9 +534,14 @@ document.addEventListener("DOMContentLoaded", () => {
                         updateStatus("Posicione su rostro dentro del óvalo...");
                     }
                     if (detection) {
-                        terminalState.faceDetected = true;
-                        setTerminalVideoState("face-found");  // teal — rostro detectado
-                        setIdStatusDot("face-found");
+                        // Feedback inmediato si la cara está muy chica — evita intentos de captura
+                        // que fallarían igual al final del ciclo de 5 muestras
+                        const box = detection.detection.box;
+                        const tooSmall = box.width < MIN_FACE_SIZE || box.height < MIN_FACE_SIZE;
+                        terminalState.faceDetected = !tooSmall;
+                        setTerminalVideoState(tooSmall ? "detecting" : "face-found");
+                        setIdStatusDot(tooSmall ? "detecting" : "face-found");
+                        if (tooSmall) updateStatus("Acérquese un poco más a la cámara");
                     } else {
                         terminalState.faceDetected = false;
                         setTerminalVideoState("detecting");   // naranja — sin rostro
@@ -549,39 +559,16 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     async function captureDescriptor(samples = 5, intervalMs = 150, onProgress = null) {
-        const descriptors = [];
-        const MIN_FACE_SIZE = 100;
-
-        for (let i = 0; i < samples; i++) {
-            try {
-                const detection = await faceapi
-                    .detectSingleFace(video, tinyOptions)
-                    .withFaceLandmarks()
-                    .withFaceDescriptor();
-
-                if (detection && detection.descriptor) {
-                    const box = detection.detection.box;
-                    if (box.width >= MIN_FACE_SIZE && box.height >= MIN_FACE_SIZE) {
-                        descriptors.push(Array.from(detection.descriptor));
-                        if (onProgress) onProgress(descriptors.length);
-                    }
-                }
-            } catch (error) {
-                console.error(`Error capturando muestra ${i + 1}:`, error);
-            }
-            if (i < samples - 1) await sleep(intervalMs);
-        }
-
-        if (descriptors.length < 3) {
-            throw new Error(`Solo se capturaron ${descriptors.length} muestras válidas (mínimo 3). Acerque el rostro a la cámara.`);
-        }
-
-        const averaged = new Array(128).fill(0);
-        for (let i = 0; i < 128; i++) {
-            let sum = 0;
-            for (const desc of descriptors) sum += desc[i];
-            averaged[i] = sum / descriptors.length;
-        }
+        const { averaged } = await captureFaceSamples(video, tinyOptions, {
+            samples,
+            intervalMs,
+            minFaceSize: MIN_FACE_SIZE,
+            minRequired: 3,
+            onProgress,
+            onRejectedSample: (reason, detail) => {
+                if (reason === 'error') console.error('Error capturando muestra:', detail);
+            },
+        });
         return averaged;
     }
 
@@ -682,8 +669,9 @@ document.addEventListener("DOMContentLoaded", () => {
                 } else {
                     await finishCaptureProgress("error");
 
-                    // No reconocido — forzar naranja y bloquear drawLoop 2 segundos
-                    terminalState.notRecognizedUntil = Date.now() + 2000;
+                    // No reconocido — forzar naranja y bloquear drawLoop.
+                    // Reducido de 2s a 1.2s para que el siguiente intento no se sienta tan lento.
+                    terminalState.notRecognizedUntil = Date.now() + 1200;
                     terminalState.inNotRecognizedCooldown = true;
                     setTerminalVideoState("detecting");
                     setIdStatusDot("detecting");
@@ -697,7 +685,7 @@ document.addEventListener("DOMContentLoaded", () => {
             } finally {
                 if (terminalState.identifyInterval) terminalState.isProcessing = false;
             }
-        }, 3000);
+        }, 1500); // Reducido de 3000ms: con el cooldown ya acotado, un intervalo más corto evita esperas innecesarias entre intentos
     }
 
     function stopAutoIdentification() {

--- a/resources/js/shared/FaceCaptureApp.js
+++ b/resources/js/shared/FaceCaptureApp.js
@@ -14,6 +14,8 @@
  * @version 2.1.0
  */
 
+import { captureFaceSamples } from './face-capture-core.js';
+
 /**
  * Configuración global de la aplicación
  */
@@ -758,88 +760,51 @@ export class FaceCaptureApp {
         intervalMs = CONFIG.CAPTURE.intervalMs,
         onProgress = null
     ) {
-        const descriptors = [];
-        const scores = [];
-        let attempts = 0;
-        let lastValidBox = null;
-        const maxAttempts = samples * 3;
         const minFaceSize = CONFIG.CAPTURE.minFaceSize || 120;
         const minRequired = CONFIG.CAPTURE.minSamples || Math.ceil(samples * 0.7);
+        const maxAttempts = samples * 3;
 
-        while (descriptors.length < samples && attempts < maxAttempts) {
-            attempts++;
+        let validCount = 0;
 
-            try {
-                const detection = await faceapi
-                    .detectSingleFace(this.video, this.tinyOptions)
-                    .withFaceLandmarks()
-                    .withFaceDescriptor();
-
-                if (detection?.descriptor) {
-                    const box = detection.detection.box;
-                    if (box.width >= minFaceSize && box.height >= minFaceSize) {
-                        descriptors.push(detection.descriptor);
-                        scores.push(detection.detection.score);
-                        lastValidBox = box;
-                        if (onProgress) onProgress(descriptors.length);
-                        this.updateStatus(
-                            `Capturando muestra ${descriptors.length} de ${samples}... no te muevas`
-                        );
-                    } else {
-                        console.warn(`Rostro muy pequeño: ${Math.round(box.width)}x${Math.round(box.height)}px (mínimo ${minFaceSize}px)`);
-                        this.updateStatus(
-                            `Acércate más a la cámara (${descriptors.length} de ${samples})`
-                        );
-                    }
-                } else {
-                    this.updateStatus(
-                        `Buscando rostro... (${descriptors.length} de ${samples})`
-                    );
+        const result = await captureFaceSamples(this.video, this.tinyOptions, {
+            samples,
+            intervalMs,
+            minFaceSize,
+            minRequired,
+            maxAttempts,
+            onProgress: (count) => {
+                validCount = count;
+                if (onProgress) onProgress(count);
+                this.updateStatus(`Capturando muestra ${count} de ${samples}... no te muevas`);
+            },
+            onRejectedSample: (reason, detail) => {
+                if (reason === 'too_small') {
+                    console.warn(`Rostro muy pequeño: ${Math.round(detail.width)}x${Math.round(detail.height)}px (mínimo ${minFaceSize}px)`);
+                    this.updateStatus(`Acércate más a la cámara (${validCount} de ${samples})`);
+                } else if (reason === 'no_face') {
+                    this.updateStatus(`Buscando rostro... (${validCount} de ${samples})`);
+                } else if (reason === 'error') {
+                    console.warn('Error en captura individual:', detail);
                 }
+            },
+        });
 
-                await this.sleep(intervalMs);
-            } catch (error) {
-                console.warn("Error en captura individual:", error);
-                await this.sleep(intervalMs * 2);
-            }
+        if (result.samples.length < samples) {
+            console.info(`Capturadas ${result.samples.length} de ${samples} muestras (mínimo ${minRequired} cumplido)`);
         }
 
-        if (descriptors.length < minRequired) {
-            throw new Error(
-                `Solo se capturaron ${descriptors.length} de ${samples} muestras requeridas. Acércate más a la cámara e intenta nuevamente.`
-            );
-        }
+        const lastValid = result.samples[result.samples.length - 1];
+        const scores = result.samples.map((s) => s.score);
 
-        if (descriptors.length < samples) {
-            console.info(`Capturadas ${descriptors.length} de ${samples} muestras (mínimo ${minRequired} cumplido)`);
-        }
-
-        this._lastCaptureSamples = descriptors.length;
+        this._lastCaptureSamples = result.samples.length;
         this._lastCaptureAvgScore = scores.length
             ? scores.reduce((a, b) => a + b, 0) / scores.length
             : 0;
-        this._lastFaceCropBase64 = lastValidBox
-            ? this.extractFaceCrop(lastValidBox)
+        this._lastFaceCropBase64 = lastValid
+            ? this.extractFaceCrop(lastValid.box)
             : null;
 
-        return this.averageDescriptors(descriptors);
-    }
-
-    averageDescriptors(descriptors) {
-        const length = CONFIG.CAPTURE.descriptorLength;
-        const averaged = new Float32Array(length).fill(0);
-
-        for (const descriptor of descriptors) {
-            for (let i = 0; i < length; i++) {
-                averaged[i] += descriptor[i];
-            }
-        }
-
-        for (let i = 0; i < length; i++) {
-            averaged[i] /= descriptors.length;
-        }
-
-        return Array.from(averaged);
+        return result.averaged;
     }
 
     // =========================================================================

--- a/resources/js/shared/face-capture-core.js
+++ b/resources/js/shared/face-capture-core.js
@@ -1,0 +1,128 @@
+/**
+ * =============================================================================
+ * NÚCLEO COMPARTIDO DE CAPTURA FACIAL (matemática/captura, no UI)
+ * =============================================================================
+ *
+ * @fileoverview Lógica de captura de múltiples muestras de descriptor facial y su
+ *               promediado, extraída de mark.js, terminal.js y FaceCaptureApp.js
+ *               para que un ajuste de tuning (tamaño mínimo de cara, umbrales) se
+ *               haga en un solo lugar. Deliberadamente NO incluye manejo de DOM ni
+ *               máquinas de estado de pantalla — cada caller (marcación manual,
+ *               terminal/kiosko, enrolamiento) tiene su propio flujo de UI distinto.
+ *
+ * @requires face-api.js cargado globalmente (faceapi) antes de invocar estas funciones.
+ */
+
+/**
+ * Captura múltiples muestras válidas del descriptor facial de un elemento <video>.
+ *
+ * Dos modos de uso según `maxAttempts`:
+ * - `maxAttempts === samples` (default): intenta exactamente `samples` veces, tantas
+ *   muestras válidas como se logren capturar (comportamiento de mark.js/terminal.js).
+ * - `maxAttempts > samples`: reintenta hasta lograr `samples` muestras válidas o
+ *   agotar los intentos (comportamiento de FaceCaptureApp para enrolamiento, donde
+ *   se prioriza calidad sobre velocidad).
+ *
+ * @param {HTMLVideoElement} video
+ * @param {faceapi.TinyFaceDetectorOptions} tinyOptions
+ * @param {Object} [options]
+ * @param {number} [options.samples=5] - Cantidad objetivo de muestras válidas.
+ * @param {number} [options.intervalMs=150] - Espera entre intentos.
+ * @param {number} [options.minFaceSize=100] - Ancho/alto mínimo en px del bounding box para aceptar una muestra.
+ * @param {number} [options.minRequired=3] - Mínimo de muestras válidas para no lanzar error.
+ * @param {number} [options.maxAttempts] - Intentos máximos (default: igual a `samples`, sin reintentos extra).
+ * @param {(validCount: number) => void} [options.onProgress] - Se llama cada vez que se acepta una muestra válida.
+ * @param {(reason: 'too_small'|'no_face'|'error', detail?: any) => void} [options.onRejectedSample] - Se llama cuando un intento no produce una muestra válida.
+ * @returns {Promise<{descriptors: number[][], samples: Array<{descriptor: number[], box: Object, score: number}>, averaged: number[]}>}
+ * @throws {Error} Si no se alcanza `minRequired` muestras válidas.
+ */
+export async function captureFaceSamples(video, tinyOptions, options = {}) {
+    const {
+        samples = 5,
+        intervalMs = 150,
+        minFaceSize = 100,
+        minRequired = 3,
+        maxAttempts = samples,
+        onProgress = null,
+        onRejectedSample = null,
+    } = options;
+
+    const collected = [];
+    let attempts = 0;
+
+    while (collected.length < samples && attempts < maxAttempts) {
+        attempts++;
+
+        try {
+            const detection = await faceapi
+                .detectSingleFace(video, tinyOptions)
+                .withFaceLandmarks()
+                .withFaceDescriptor();
+
+            if (detection?.descriptor) {
+                const box = detection.detection.box;
+                if (box.width >= minFaceSize && box.height >= minFaceSize) {
+                    collected.push({
+                        descriptor: Array.from(detection.descriptor),
+                        box,
+                        score: detection.detection.score,
+                    });
+                    onProgress?.(collected.length);
+                } else {
+                    onRejectedSample?.('too_small', box);
+                }
+            } else {
+                onRejectedSample?.('no_face');
+            }
+        } catch (error) {
+            onRejectedSample?.('error', error);
+        }
+
+        if (collected.length < samples && attempts < maxAttempts) {
+            await sleep(intervalMs);
+        }
+    }
+
+    if (collected.length < minRequired) {
+        throw new Error(
+            `Solo se capturaron ${collected.length} muestras válidas (mínimo ${minRequired}). Acerque el rostro a la cámara.`
+        );
+    }
+
+    const descriptors = collected.map((s) => s.descriptor);
+
+    return {
+        descriptors,
+        samples: collected,
+        averaged: averageDescriptors(descriptors),
+    };
+}
+
+/**
+ * Promedia N descriptores faciales (arrays de 128 floats) elemento a elemento.
+ * @param {number[][]} descriptors
+ * @param {number} [length=128]
+ * @returns {number[]}
+ */
+export function averageDescriptors(descriptors, length = 128) {
+    const averaged = new Array(length).fill(0);
+
+    for (const descriptor of descriptors) {
+        for (let i = 0; i < length; i++) {
+            averaged[i] += descriptor[i];
+        }
+    }
+    for (let i = 0; i < length; i++) {
+        averaged[i] /= descriptors.length;
+    }
+
+    return averaged;
+}
+
+/**
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
+export function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/resources/views/attendances/terminal-setup-invalid.blade.php
+++ b/resources/views/attendances/terminal-setup-invalid.blade.php
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="es">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Enlace de configuración inválido</title>
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: Arial, sans-serif;
+            background: #0f172a;
+            color: #e2e8f0;
+            min-height: 100dvh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            text-align: center;
+            padding: 2rem;
+        }
+        .container { max-width: 480px; }
+        .icon {
+            width: 80px; height: 80px;
+            border-radius: 50%;
+            background: #1e293b;
+            display: flex; align-items: center; justify-content: center;
+            margin: 0 auto 1.5rem;
+            border: 2px solid #ef4444;
+        }
+        .icon svg { width: 40px; height: 40px; color: #ef4444; }
+        h1 { font-size: 1.5rem; font-weight: 700; margin-bottom: 0.75rem; }
+        p { font-size: 1rem; color: #94a3b8; line-height: 1.6; margin-bottom: 0.5rem; }
+    </style>
+</head>
+
+<body>
+    <div class="container">
+        <div class="icon">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+            </svg>
+        </div>
+        <h1>Enlace de configuración inválido</h1>
+        <p>Este enlace ya fue usado, expiró, o no corresponde a ningún terminal.</p>
+        <p>Solicite un nuevo enlace de configuración desde el panel de administración (Terminales).</p>
+    </div>
+</body>
+
+</html>

--- a/resources/views/attendances/terminal-setup.blade.php
+++ b/resources/views/attendances/terminal-setup.blade.php
@@ -1,0 +1,114 @@
+<!doctype html>
+<html lang="es">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Configurar terminal — {{ $terminal->name }}</title>
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: Arial, sans-serif;
+            background: #0f172a;
+            color: #e2e8f0;
+            min-height: 100dvh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            text-align: center;
+            padding: 2rem;
+        }
+        .container { max-width: 480px; width: 100%; }
+        .icon {
+            width: 80px; height: 80px;
+            border-radius: 50%;
+            background: #1e293b;
+            display: flex; align-items: center; justify-content: center;
+            margin: 0 auto 1.5rem;
+            border: 2px solid #38bdf8;
+        }
+        .icon svg { width: 40px; height: 40px; color: #38bdf8; }
+        h1 { font-size: 1.5rem; font-weight: 700; margin-bottom: 0.75rem; }
+        p { font-size: 1rem; color: #94a3b8; line-height: 1.6; margin-bottom: 0.5rem; }
+        .terminal-meta { font-size: 0.875rem; color: #64748b; margin: 1rem 0 2rem; }
+        button {
+            font: inherit;
+            font-weight: 600;
+            font-size: 1rem;
+            padding: 0.85rem 1.75rem;
+            border-radius: 0.75rem;
+            border: none;
+            background: #38bdf8;
+            color: #0f172a;
+            cursor: pointer;
+        }
+        button:disabled { opacity: 0.6; cursor: not-allowed; }
+        button:not(:disabled):hover { background: #7dd3fc; }
+        .status { margin-top: 1.25rem; font-size: 0.9rem; min-height: 1.5rem; }
+        .status--error { color: #f87171; }
+        .status--success { color: #4ade80; }
+    </style>
+</head>
+
+<body>
+    <div class="container">
+        <div class="icon">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9 17.25v1.007a3 3 0 01-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0115 18.257V17.25m6-12V15a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 15V5.25m18 0A2.25 2.25 0 0018.75 3H5.25A2.25 2.25 0 003 5.25m18 0V12a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 12V5.25" />
+            </svg>
+        </div>
+        <h1>Configurar terminal</h1>
+        <p>Este dispositivo se vinculará como el terminal de marcación de la sucursal indicada, habilitando la marcación sin conexión.</p>
+        <div class="terminal-meta">{{ $terminal->name }} — {{ $terminal->branch?->name }}</div>
+
+        <button type="button" id="btnClaim">Vincular este dispositivo</button>
+        <div id="status" class="status" role="status" aria-live="polite"></div>
+    </div>
+
+    <script>
+        const btn = document.getElementById('btnClaim');
+        const statusEl = document.getElementById('status');
+        const csrf = document.querySelector('meta[name="csrf-token"]').content;
+
+        btn.addEventListener('click', async () => {
+            btn.disabled = true;
+            statusEl.textContent = 'Vinculando...';
+            statusEl.className = 'status';
+
+            try {
+                const response = await fetch(window.location.pathname.replace(/\/$/, '') + '/claim', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-CSRF-TOKEN': csrf },
+                });
+                const data = await response.json();
+
+                if (!data.ok) {
+                    statusEl.textContent = data.message || 'No se pudo vincular el dispositivo.';
+                    statusEl.className = 'status status--error';
+                    btn.disabled = false;
+                    return;
+                }
+
+                // Almacenamiento provisorio del token — en la fase de sincronización offline
+                // (IndexedDB, módulo terminal-offline/) este valor pasa a vivir en el store
+                // `terminal_meta` en vez de localStorage.
+                localStorage.setItem('nominapp_terminal_token', data.token);
+                localStorage.setItem('nominapp_terminal_code', data.terminal.code);
+
+                statusEl.textContent = 'Dispositivo vinculado correctamente. Redirigiendo...';
+                statusEl.className = 'status status--success';
+
+                setTimeout(() => {
+                    window.location.href = '/terminal/' + data.terminal.code;
+                }, 1200);
+            } catch (error) {
+                statusEl.textContent = 'Error de conexión. Intente nuevamente.';
+                statusEl.className = 'status status--error';
+                btn.disabled = false;
+            }
+        });
+    </script>
+</body>
+
+</html>

--- a/resources/views/filament/modals/terminal-setup-link.blade.php
+++ b/resources/views/filament/modals/terminal-setup-link.blade.php
@@ -1,0 +1,22 @@
+{{-- Modal con el enlace/QR de configuración de un solo uso para provisionar el terminal offline --}}
+<div class="space-y-4">
+    <p class="text-sm text-gray-600 dark:text-gray-300">
+        Abra este enlace <strong>una sola vez, con el dispositivo conectado a internet</strong>, durante la instalación
+        física del terminal. Vence en <strong>{{ $expiresInMinutes }} minutos</strong> y no puede reutilizarse.
+    </p>
+
+    <div class="flex justify-center">
+        <div style="display:inline-block;background:#fff;padding:12px;border-radius:8px;border:1px solid #e5e7eb">
+            {!! \SimpleSoftwareIO\QrCode\Facades\QrCode::size(200)->generate($url) !!}
+        </div>
+    </div>
+
+    <div class="rounded-lg bg-gray-50 dark:bg-gray-800 p-3 text-xs break-all font-mono text-gray-700 dark:text-gray-300">
+        {{ $url }}
+    </div>
+
+    <p class="text-xs text-gray-500 dark:text-gray-400">
+        Si el terminal ya tiene un token activo, este enlace lo reemplaza al vincularse — el token anterior queda
+        inválido de inmediato.
+    </p>
+</div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Http\Controllers\Api\TerminalEmployeeSyncController;
+use App\Http\Controllers\Api\TerminalEventSyncController;
+use App\Http\Controllers\Api\TerminalHeartbeatController;
+use Illuminate\Support\Facades\Route;
+
+/*
+|--------------------------------------------------------------------------
+| API Routes — Sincronización de Terminales (marcación offline vía PWA)
+|--------------------------------------------------------------------------
+|
+| Autenticadas con Laravel Sanctum (bearer token emitido al provisionar el
+| terminal, ver TerminalSetupController). Ability requerida: 'terminal:sync'.
+| Solo consumidas por el kiosko/terminal — el flujo de celular personal
+| (mark.js) sigue usando las rutas de sesión en routes/web.php sin cambios.
+|
+*/
+
+Route::prefix('v1/terminal')->name('api.terminal.')->middleware(['auth:sanctum'])->group(function () {
+    Route::get('/employees/sync', [TerminalEmployeeSyncController::class, 'index'])
+        ->middleware('ability:terminal:sync')
+        ->name('employees.sync');
+
+    Route::post('/events/sync', [TerminalEventSyncController::class, 'store'])
+        ->middleware('ability:terminal:sync')
+        ->name('events.sync');
+
+    Route::post('/heartbeat', [TerminalHeartbeatController::class, 'store'])
+        ->middleware('ability:terminal:sync')
+        ->name('heartbeat');
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,6 +22,7 @@ use App\Http\Controllers\PayrollController;
 use App\Http\Controllers\SalaryReportController;
 use App\Http\Controllers\ScheduleEmployeeController;
 use App\Http\Controllers\ShiftPlannerController;
+use App\Http\Controllers\TerminalSetupController;
 use App\Http\Controllers\VacationDocumentController;
 use App\Http\Controllers\VacationReportController;
 use App\Http\Controllers\WarningController;
@@ -48,6 +49,13 @@ Route::get('/terminal', [AttendanceFaceMarkController::class, 'terminal'])->name
 
 // Terminal identificada por código — nueva arquitectura
 Route::get('/terminal/{code}', [AttendanceFaceMarkController::class, 'terminalByCode'])->name('terminal.show');
+
+// Provisión del terminal como PWA offline — enlace de un solo uso generado desde TerminalResource,
+// emite el token Sanctum que el kiosko usará contra la API de sincronización (routes/api.php).
+Route::prefix('terminal/{code}/setup/{setupToken}')->name('terminal.setup.')->middleware('throttle:10,1')->group(function () {
+    Route::get('/', [TerminalSetupController::class, 'show'])->name('show');
+    Route::post('/claim', [TerminalSetupController::class, 'claim'])->name('claim');
+});
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Dos mejoras independientes al proceso de marcación de asistencia, en respuesta al reclamo de Macro/Sedacosmetica de que algunos empleados "a veces no son reconocidos, o tarda" al marcar por reconocimiento facial, más una base para que la marcación no dependa de la conexión a internet.

### Parte A — Confiabilidad y velocidad del reconocimiento facial (`96c727a`)
- Feedback en tiempo real durante la captura (`mark.js`/`terminal.js`): avisa "acérquese más" apenas detecta un rostro chico, en vez de esperar a que falle el ciclo completo de 5 muestras.
- Cooldowns tras un fallo reducidos (3s→1.5s en celular, 2s→1.2s en terminal) y el intervalo de reintento del terminal (3s→1.5s), para que un rechazo no se sienta tan lento.
- Lógica de captura/promediado de descriptores unificada en `resources/js/shared/face-capture-core.js` (antes duplicada casi textual en `mark.js`, `terminal.js` y `FaceCaptureApp.js`), así el tuning de umbrales queda en un solo lugar.
- Widget nuevo "Empleados con más fallos de marcación" en `AttendanceMarkFailureResource` (query agregada única, últimos 30 días) para detectar proactivamente a quién le conviene re-inscribir su rostro.
- **Pendiente, fuera de este PR**: ajustar `face_threshold`/`face_min_confidence_gap` en `GeneralSettings` — necesita datos reales de producción (`AttendanceMarkFailure`) que todavía no tengo.

### Parte B — API Sanctum para sincronización offline de terminales, Fase 1 de N (`c889d66`)
Primer paso hacia marcación offline vía PWA en el kiosko de sucursal. La sesión de Laravel expira a los 120 minutos, así que un terminal sin conexión por horas no podía sincronizar limpiamente al reconectar — se necesitaba autenticación por token desacoplada de la sesión.

- `Terminal` usa `HasApiTokens`; provisión en dos pasos: el admin genera un enlace de configuración de un solo uso desde `TerminalResource` ("Generar enlace de configuración" / "Revocar token"), el kiosko lo abre una vez online y reclama un token Sanctum (`terminal:sync`).
- Nueva API en `routes/api.php` (`auth:sanctum` + `ability:terminal:sync`):
  - `GET /api/v1/terminal/employees/sync` — delta de empleados/descriptores faciales por sucursal, con tombstones.
  - `POST /api/v1/terminal/events/sync` — envío en lote idempotente de marcaciones (`client_event_id` generado en el cliente), con detección de conflictos cuando la secuencia ya no es válida en el servidor.
  - `POST /api/v1/terminal/heartbeat`.
- La máquina de estados de marcación se extrae a `AttendanceEvent::allowedNextEventTypes()`, reutilizada tanto por el flujo de sesión existente como por el nuevo servicio de sync.
- `/marcar/*` (celular personal) queda intacto — esta fase cubre solo el kiosko de sucursal. El resto de las fases (service worker, IndexedDB, cola offline, heartbeat/staleness en Filament) quedan para próximas entregas.

## Test plan

- [x] `php -l` en todos los archivos PHP nuevos/modificados
- [x] `vendor/bin/pint --dirty`
- [x] Arranque completo de la app (`route:list`, resolución de clases/servicios vía el contenedor) sin errores
- [x] Las 2 migraciones nuevas corren limpio de forma aislada
- [x] Flujo end-to-end real por HTTP (Sanctum bearer token, delta sync, idempotencia, y el caso de conflicto por secuencia inválida) validado contra un esquema reconstruido a mano en sqlite
- [ ] **`php artisan migrate` + `php artisan test --compact` contra MySQL real** — no se pudo ejecutar en este sandbox (sin MySQL disponible, y el historial de migraciones de este repo usa SQL específico de MySQL). Correr antes de mergear.
- [ ] Prueba manual en navegador de los cambios de UX facial (feedback en tiempo real, cooldowns)
- [ ] Probar el flujo de provisión del terminal (generar enlace → reclamar token → curl a los 3 endpoints) contra un entorno real

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH)_