### PR TITLE
Marcación offline: service worker del kiosko (Fase 2 de N)

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,109 @@
+/**
+ * =============================================================================
+ * SERVICE WORKER — KIOSKO DE MARCACIÓN (offline shell)
+ * =============================================================================
+ *
+ * Hand-rolled, sin Workbox/vite-plugin-pwa — alcance acotado a una sola página
+ * (/terminal/*), registrado con scope explícito en terminal.blade.php.
+ *
+ * Responsabilidad de esta fase: que el shell del kiosko, sus assets de Vite y
+ * los modelos de face-api.js queden disponibles offline. NO incluye todavía
+ * matching client-side ni cola de eventos (fases posteriores) — los POST a
+ * /marcar/* siguen requiriendo red en esta fase.
+ */
+
+const CACHE_VERSION = 'nominapp-terminal-v1';
+
+/**
+ * Contenido estático que nunca cambia sin un deploy — cache-first.
+ * `/build/assets/` se cachea completo (no solo `terminal-*`): Vite separa en
+ * chunks compartidos los módulos importados por varios entrypoints (ej.
+ * face-capture-core.js, usado también por mark.js/capture-face.js), así que
+ * filtrar por nombre del entrypoint deja afuera esos chunks y rompe el offline.
+ */
+const CACHE_FIRST_PATTERNS = [
+    /^\/models\//, // modelos de face-api.js (tinyFaceDetector, faceLandmark68, faceRecognition)
+    /^\/js\/face-api\.min\.js$/,
+    /^\/build\/assets\//, // todos los bundles JS/CSS de Vite (nombres con hash de contenido — seguros de cachear indefinidamente)
+];
+
+/** Shell HTML del kiosko — stale-while-revalidate para que un reload offline funcione. */
+const SHELL_PATTERNS = [
+    /^\/terminal\/?$/,
+    /^\/terminal\/[a-z0-9]+\/?$/,
+];
+
+self.addEventListener('install', () => {
+    // Kiosko de un solo propósito: aplicar la versión nueva del SW sin esperar
+    // a que se cierren todas las pestañas abiertas.
+    self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+    event.waitUntil(
+        caches.keys()
+            .then((keys) => Promise.all(
+                keys.filter((key) => key !== CACHE_VERSION).map((key) => caches.delete(key))
+            ))
+            .then(() => self.clients.claim())
+    );
+});
+
+function matchesAny(pathname, patterns) {
+    return patterns.some((pattern) => pattern.test(pathname));
+}
+
+async function cacheFirst(request) {
+    const cache = await caches.open(CACHE_VERSION);
+    const cached = await cache.match(request);
+    if (cached) return cached;
+
+    const response = await fetch(request);
+    if (response.ok) cache.put(request, response.clone());
+    return response;
+}
+
+async function staleWhileRevalidate(request) {
+    const cache = await caches.open(CACHE_VERSION);
+    const cached = await cache.match(request);
+
+    const networkUpdate = fetch(request)
+        .then((response) => {
+            if (response.ok) cache.put(request, response.clone());
+            return response;
+        })
+        .catch(() => null);
+
+    if (cached) {
+        // Responder al instante con la copia cacheada; la red se actualiza en segundo plano.
+        networkUpdate.catch(() => {});
+        return cached;
+    }
+
+    const fresh = await networkUpdate;
+    return fresh || Response.error();
+}
+
+self.addEventListener('fetch', (event) => {
+    const { request } = event;
+
+    // Solo GET — POST/PUT/DELETE (ej. /marcar, /api/*) pasan directo a la red sin intervención.
+    if (request.method !== 'GET') return;
+
+    const url = new URL(request.url);
+    if (url.origin !== self.location.origin) return;
+
+    const { pathname } = url;
+
+    if (matchesAny(pathname, CACHE_FIRST_PATTERNS)) {
+        event.respondWith(cacheFirst(request));
+        return;
+    }
+
+    if (matchesAny(pathname, SHELL_PATTERNS)) {
+        event.respondWith(staleWhileRevalidate(request));
+        return;
+    }
+
+    // Todo lo demás no se intercepta — comportamiento normal del navegador.
+});

--- a/resources/views/attendances/terminal.blade.php
+++ b/resources/views/attendances/terminal.blade.php
@@ -70,6 +70,14 @@
         };
     </script>
     @endisset
+
+    {{-- Service worker offline — scope acotado a /terminal/, no afecta el resto de la app --}}
+    <script>
+        if ('serviceWorker' in navigator) {
+            navigator.serviceWorker.register('/sw.js', { scope: '/terminal/' })
+                .catch((error) => console.warn('No se pudo registrar el service worker:', error));
+        }
+    </script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary

Segundo paso de la marcación offline vía PWA en el kiosko de sucursal (Fase 1 — API Sanctum — mergeada en #77). Esta fase cubre únicamente que el kiosko cargue completamente offline tras la primera visita online: shell HTML, bundles de Vite y modelos de face-api.js quedan cacheados por un service worker.

- Nuevo `public/sw.js` — **hand-rolled, sin dependencias nuevas** (se descartó `vite-plugin-pwa`, decisión confirmada con el usuario: el caso de uso no justifica la capa de Workbox).
  - `cache-first` para `/models/*` (modelos de face-api.js), `/js/face-api.min.js`, y todo `/build/assets/*`.
  - `stale-while-revalidate` para el shell HTML (`/terminal` y `/terminal/{code}`).
  - Scope de registro `/terminal/` — no toca ninguna otra ruta de la app.
- `resources/views/attendances/terminal.blade.php` registra el service worker.
- **Sin cambios de comportamiento online**: el kiosko sigue usando `/marcar/*` (sesión) exactamente igual que antes. No incluye todavía matching client-side, IndexedDB ni cola de eventos offline — eso queda para las próximas fases (3 y 4).

### Nota de diseño

El plan original cacheaba solo `/build/assets/terminal-*`. Al buildear de verdad, el manifest de Vite mostró que `terminal.js` importa un chunk compartido (`face-capture-core-*.js`, extraído porque también lo usa `mark.js`) — filtrar por nombre del entrypoint lo dejaba afuera y rompía el offline. Se corrigió cacheando `/build/assets/` completo, que es seguro porque todos los nombres llevan hash de contenido.

## Test plan

- [x] Build real de Vite (`npm run build`) para obtener los nombres de archivo con hash reales y confirmar qué se cachea.
- [x] Verificación end-to-end con Playwright (Chromium real) contra un servidor Laravel real:
  - Service worker registra con scope `/terminal/`.
  - Tras la carga inicial se cachean: los 3 modelos de face-api.js completos (shards + manifests), el shell HTML, `face-api.min.js`, y los bundles de Vite (incluido el chunk compartido).
  - Con la red completamente cortada (`context.setOffline(true)`), un reload del kiosko no tira error, renderiza el elemento de video, y un fetch de un modelo facial responde `200` servido desde el SW.
- [x] `vendor/bin/pint --dirty` sin cambios pendientes.
- [ ] Probar en un dispositivo/navegador real (no headless) el ciclo completo: cargar el kiosko online una vez, activar modo avión, confirmar que carga y llega a la pantalla de detección facial.
- [ ] Confirmar que un segundo deploy (cambio trivial en `sw.js`) actualiza el kiosko sin quedar pegado a assets viejos (ciclo `skipWaiting` + limpieza de cachés en `activate`).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH)_