### PR TITLE
Marcación offline: matching facial client-side vía IndexedDB (Fase 3 de N)

### DIFF
--- a/app/Http/Controllers/Api/TerminalEmployeeSyncController.php
+++ b/app/Http/Controllers/Api/TerminalEmployeeSyncController.php
@@ -3,6 +3,9 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Models\AttendanceDay;
+use App\Models\AttendanceEvent;
+use App\Models\Employee;
 use App\Models\Terminal;
 use App\Services\EmployeeDescriptorSyncService;
 use Carbon\Carbon;
@@ -46,5 +49,41 @@ class TerminalEmployeeSyncController extends Controller
         $delta = $this->syncService->deltaSince($terminal, $since);
 
         return response()->json(array_merge(['ok' => true], $delta));
+    }
+
+    /**
+     * GET /api/v1/terminal/employees/{employee}/status
+     *
+     * Estado de marcación del día en curso para un empleado ya identificado
+     * localmente por el kiosko (matching client-side, ver terminal-offline/matcher.js).
+     * El kiosko todavía depende de esta consulta en línea para saber qué
+     * eventos son válidos a continuación — la resolución 100% offline de este
+     * estado es responsabilidad de una fase posterior (cola de eventos).
+     */
+    public function status(Request $request, Employee $employee): JsonResponse
+    {
+        /** @var Terminal $terminal */
+        $terminal = $request->user();
+
+        if ($employee->status !== 'active' || $employee->branch_id !== $terminal->branch_id) {
+            return response()->json([
+                'ok' => false,
+                'message' => 'Empleado no disponible para este terminal.',
+            ], 404);
+        }
+
+        $today = now(config('app.timezone'))->toDateString();
+
+        $day = AttendanceDay::where('employee_id', $employee->id)->where('date', $today)->first();
+        $last = $day
+            ? AttendanceEvent::where('attendance_day_id', $day->id)->latest('recorded_at')->first()
+            : null;
+
+        return response()->json([
+            'ok' => true,
+            'last_event' => $last?->event_type,
+            'last_event_time' => $last?->recorded_at?->format('H:i'),
+            'allowed_events' => AttendanceEvent::allowedNextEventTypes($last?->event_type),
+        ]);
     }
 }

--- a/app/Services/AttendanceEventSyncService.php
+++ b/app/Services/AttendanceEventSyncService.php
@@ -171,7 +171,7 @@ class AttendanceEventSyncService
             'recorded_at' => $recordedAt,
             'synced_at' => now(),
             'source' => 'terminal',
-            'location' => $eventData['location'] ?? null,
+            'location' => $eventData['location'] ?? $this->resolveFallbackLocation($terminal, $employee),
             'terminal_id' => $terminal->id,
             'branch_mismatch' => $branchMismatch,
         ]);
@@ -180,6 +180,26 @@ class AttendanceEventSyncService
             'client_event_id' => $clientEventId,
             'status' => 'synced',
             'event_id' => $event->id,
+        ];
+    }
+
+    /**
+     * El kiosko no envía GPS (mismo criterio que AttendanceFaceMarkController::store()
+     * en modo terminal) — se usan las coordenadas de la sucursal de la terminal, o
+     * las de la sucursal del empleado si la terminal no tiene sucursal asignada.
+     */
+    private function resolveFallbackLocation(Terminal $terminal, Employee $employee): ?array
+    {
+        $branch = $terminal->branch ?? $employee->branch;
+        $coordinates = $branch?->coordinates;
+
+        if (! $coordinates || ! isset($coordinates['lat'], $coordinates['lng'])) {
+            return null;
+        }
+
+        return [
+            'lat' => (float) $coordinates['lat'],
+            'lng' => (float) $coordinates['lng'],
         ];
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,9 +4,9 @@
     "requires": true,
     "packages": {
         "": {
-            "name": "nominapp",
             "dependencies": {
                 "@vitejs/plugin-vue": "^6.0.5",
+                "idb": "^8.0.3",
                 "leaflet": "^1.9.4",
                 "vue": "^3.5.32"
             },
@@ -1868,6 +1868,12 @@
             "engines": {
                 "node": ">= 6"
             }
+        },
+        "node_modules/idb": {
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+            "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
+            "license": "ISC"
         },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     },
     "dependencies": {
         "@vitejs/plugin-vue": "^6.0.5",
+        "idb": "^8.0.3",
         "leaflet": "^1.9.4",
         "vue": "^3.5.32"
     }

--- a/resources/css/attendances/terminal.css
+++ b/resources/css/attendances/terminal.css
@@ -350,6 +350,28 @@ html[data-theme="dark"]  .theme-toggle .icon-moon { display: none; }
     opacity: .7;
 }
 
+.idle-sync-row {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-3);
+    margin-top: var(--sp-4);
+}
+
+.idle-sync-status {
+    font-size: clamp(.6875rem, 1.75vw, .8125rem);
+    color: var(--c-muted);
+    opacity: .7;
+    min-width: 0;
+}
+
+.idle-sync-btn {
+    min-height: 32px;
+    padding: var(--sp-2) var(--sp-4);
+    font-size: clamp(.6875rem, 1.5vw, .8125rem);
+    text-transform: none;
+    letter-spacing: normal;
+}
+
 .idle-hint {
     position: absolute;
     bottom: var(--sp-8);

--- a/resources/js/attendances/terminal-offline/db.js
+++ b/resources/js/attendances/terminal-offline/db.js
@@ -1,0 +1,133 @@
+/**
+ * =============================================================================
+ * INDEXEDDB — CACHÉ LOCAL DEL TERMINAL
+ * =============================================================================
+ *
+ * @fileoverview Wrapper delgado sobre `idb` para la base local del kiosko.
+ *               Se crean los 4 stores de una vez (aunque `outbound_events` y
+ *               `sync_log` recién se usan a partir de fases posteriores) para
+ *               no requerir un bump de versión de IndexedDB más adelante.
+ *
+ * Stores:
+ * - terminal_meta   — key/value: api_token, terminal_id/code/branch_id,
+ *                      cursores de sync, config de reconocimiento facial.
+ * - employees_cache — keyPath 'id': empleados activos con descriptor facial,
+ *                      scopeados a la sucursal del terminal (ver sync.js).
+ * - outbound_events — keyPath 'client_event_id': cola de marcaciones
+ *                      pendientes de sincronizar (fase de cola offline).
+ * - sync_log        — autoIncrement: historial breve de intentos de sync,
+ *                      para diagnóstico en pantalla.
+ */
+
+import { openDB } from 'idb';
+
+const DB_NAME = 'nominapp-terminal';
+const DB_VERSION = 1;
+
+/** @type {Promise<import('idb').IDBPDatabase>|null} */
+let dbPromise = null;
+
+/** @returns {Promise<import('idb').IDBPDatabase>} */
+export function getDb() {
+    if (!dbPromise) {
+        dbPromise = openDB(DB_NAME, DB_VERSION, {
+            upgrade(db) {
+                if (!db.objectStoreNames.contains('terminal_meta')) {
+                    db.createObjectStore('terminal_meta');
+                }
+                if (!db.objectStoreNames.contains('employees_cache')) {
+                    db.createObjectStore('employees_cache', { keyPath: 'id' });
+                }
+                if (!db.objectStoreNames.contains('outbound_events')) {
+                    db.createObjectStore('outbound_events', { keyPath: 'client_event_id' });
+                }
+                if (!db.objectStoreNames.contains('sync_log')) {
+                    db.createObjectStore('sync_log', { keyPath: 'id', autoIncrement: true });
+                }
+            },
+        });
+    }
+    return dbPromise;
+}
+
+/**
+ * Lee un valor de `terminal_meta`.
+ * @param {string} key
+ * @returns {Promise<any>}
+ */
+export async function getMeta(key) {
+    const db = await getDb();
+    return db.get('terminal_meta', key);
+}
+
+/**
+ * Escribe un valor en `terminal_meta`.
+ * @param {string} key
+ * @param {any} value
+ */
+export async function setMeta(key, value) {
+    const db = await getDb();
+    return db.put('terminal_meta', value, key);
+}
+
+/**
+ * Migración única del token guardado en localStorage por la pantalla de
+ * configuración (terminal-setup.blade.php) hacia IndexedDB. Se puede llamar
+ * en cada carga: es un no-op si ya no queda nada en localStorage.
+ * @returns {Promise<void>}
+ */
+export async function migrateTokenFromLocalStorage() {
+    const legacyToken = localStorage.getItem('nominapp_terminal_token');
+    if (!legacyToken) return;
+
+    const legacyCode = localStorage.getItem('nominapp_terminal_code');
+    await setMeta('api_token', legacyToken);
+    if (legacyCode) await setMeta('terminal_code', legacyCode);
+
+    localStorage.removeItem('nominapp_terminal_token');
+    localStorage.removeItem('nominapp_terminal_code');
+}
+
+/**
+ * Registra una entrada en `sync_log`, recortando el historial a las últimas 50.
+ * @param {string} type
+ * @param {boolean} ok
+ * @param {string|null} [detail]
+ */
+export async function logSync(type, ok, detail = null) {
+    const db = await getDb();
+    await db.add('sync_log', { type, ok, detail, at: Date.now() });
+
+    const allKeys = await db.getAllKeys('sync_log');
+    if (allKeys.length > 50) {
+        const tx = db.transaction('sync_log', 'readwrite');
+        for (const key of allKeys.slice(0, allKeys.length - 50)) {
+            await tx.store.delete(key);
+        }
+        await tx.done;
+    }
+}
+
+/** @returns {Promise<Array<object>>} */
+export async function getCachedEmployees() {
+    const db = await getDb();
+    return db.getAll('employees_cache');
+}
+
+/**
+ * Aplica un delta de sincronización de empleados: upsert de los modificados,
+ * borrado de los tombstones.
+ * @param {Array<object>} employees
+ * @param {Array<number>} tombstones
+ */
+export async function applyEmployeesDelta(employees, tombstones) {
+    const db = await getDb();
+    const tx = db.transaction('employees_cache', 'readwrite');
+    for (const employee of employees) {
+        await tx.store.put(employee);
+    }
+    for (const id of tombstones) {
+        await tx.store.delete(id);
+    }
+    await tx.done;
+}

--- a/resources/js/attendances/terminal-offline/matcher.js
+++ b/resources/js/attendances/terminal-offline/matcher.js
@@ -1,0 +1,75 @@
+/**
+ * =============================================================================
+ * MATCHING FACIAL CLIENT-SIDE (kiosko offline)
+ * =============================================================================
+ *
+ * @fileoverview Port a JS de la lógica de identificación por distancia
+ *               euclidiana de AttendanceFaceMarkController::identifyEmployeeByDescriptor()
+ *               (backend), para poder correr el matching en el kiosko sin
+ *               depender del servidor. Mismo algoritmo, mismos criterios de
+ *               umbral/gap — la config (threshold/minGap) se sincroniza desde
+ *               GeneralSettings vía el endpoint de heartbeat (ver sync.js).
+ */
+
+/**
+ * Distancia euclidiana entre dos descriptores faciales (arrays de 128 floats).
+ * @param {number[]} a
+ * @param {number[]} b
+ * @returns {number}
+ */
+export function euclideanDistance(a, b) {
+    let sum = 0;
+    for (let i = 0; i < 128; i++) {
+        const diff = (a[i] ?? 0) - (b[i] ?? 0);
+        sum += diff * diff;
+    }
+    return Math.sqrt(sum);
+}
+
+/**
+ * Identifica al candidato más cercano a un descriptor "en vivo" dentro de la
+ * caché local de empleados, aplicando el mismo criterio de umbral + gap de
+ * confianza que el backend.
+ *
+ * @param {number[]} liveDescriptor - Descriptor capturado en el momento.
+ * @param {Array<{id: number, first_name: string, last_name: string, ci: string|null, face_descriptor: number[]}>} candidates - Empleados cacheados (employees_cache).
+ * @param {number} threshold - Distancia máxima para aceptar un match (face_threshold).
+ * @param {number} minGap - Diferencia mínima requerida con el segundo candidato (face_min_confidence_gap).
+ * @returns {{employee: object|null, distance: number, reason: 'no_match'|'ambiguous'|'no_candidates'|null}}
+ */
+export function identifyEmployee(liveDescriptor, candidates, threshold, minGap) {
+    if (!candidates || candidates.length === 0) {
+        return { employee: null, distance: Infinity, reason: 'no_candidates' };
+    }
+
+    let best = null;
+    let bestDist = Infinity;
+    let secondBestDist = Infinity;
+
+    for (const candidate of candidates) {
+        if (!Array.isArray(candidate.face_descriptor) || candidate.face_descriptor.length !== 128) continue;
+
+        const dist = euclideanDistance(liveDescriptor, candidate.face_descriptor);
+
+        if (dist < bestDist) {
+            secondBestDist = bestDist;
+            bestDist = dist;
+            best = candidate;
+        } else if (dist < secondBestDist) {
+            secondBestDist = dist;
+        }
+    }
+
+    if (!best || bestDist > threshold) {
+        return { employee: null, distance: bestDist, reason: 'no_match' };
+    }
+
+    if (secondBestDist !== Infinity) {
+        const gap = secondBestDist - bestDist;
+        if (gap < minGap) {
+            return { employee: null, distance: bestDist, reason: 'ambiguous' };
+        }
+    }
+
+    return { employee: best, distance: bestDist, reason: null };
+}

--- a/resources/js/attendances/terminal-offline/sync.js
+++ b/resources/js/attendances/terminal-offline/sync.js
@@ -1,0 +1,132 @@
+/**
+ * =============================================================================
+ * SINCRONIZACIÓN CON LA API DE TERMINALES (routes/api.php, Sanctum)
+ * =============================================================================
+ *
+ * @fileoverview Cliente delgado para /api/v1/terminal/* — delta de empleados,
+ *               heartbeat, y helper de fetch autenticado reutilizado por el
+ *               envío de eventos (ver terminal.js). Requiere que el terminal
+ *               ya haya sido provisionado (token en terminal_meta.api_token,
+ *               ver TerminalSetupController / terminal-setup.blade.php).
+ */
+
+import { getMeta, setMeta, applyEmployeesDelta, logSync } from './db.js';
+
+const API_BASE = '/api/v1/terminal';
+
+/** Error específico de token ausente/inválido — el caller decide cómo mostrarlo. */
+export class TerminalAuthError extends Error {}
+
+/**
+ * fetch autenticado con el token Sanctum del terminal.
+ * @param {string} path - Path relativo a /api/v1/terminal (ej. '/heartbeat').
+ * @param {RequestInit} [options]
+ * @returns {Promise<any>} Cuerpo JSON de la respuesta.
+ */
+export async function apiFetch(path, options = {}) {
+    const token = await getMeta('api_token');
+    if (!token) {
+        throw new TerminalAuthError('Este terminal no está configurado — falta vincular el dispositivo.');
+    }
+
+    const response = await fetch(`${API_BASE}${path}`, {
+        ...options,
+        headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+            ...(options.headers || {}),
+        },
+    });
+
+    if (response.status === 401 || response.status === 403) {
+        throw new TerminalAuthError('El token de este terminal fue revocado o expiró — necesita re-provisión.');
+    }
+
+    return response.json();
+}
+
+/**
+ * Trae el delta de empleados/descriptores desde la última sincronización y
+ * lo aplica a la caché local.
+ * @returns {Promise<{employees: number, tombstones: number}>}
+ */
+export async function syncEmployees() {
+    try {
+        const since = await getMeta('last_employee_sync_version');
+        const query = since ? `?since=${encodeURIComponent(since)}` : '';
+        const data = await apiFetch(`/employees/sync${query}`);
+
+        if (!data.ok) throw new Error(data.message || 'Error al sincronizar empleados');
+
+        await applyEmployeesDelta(data.employees, data.tombstones);
+        await setMeta('last_employee_sync_version', data.sync_version);
+        await setMeta('employees_synced_at', Date.now());
+
+        await logSync('employees_sync', true, `${data.employees.length} empleados, ${data.tombstones.length} tombstones`);
+        return { employees: data.employees.length, tombstones: data.tombstones.length };
+    } catch (error) {
+        await logSync('employees_sync', false, error.message);
+        throw error;
+    }
+}
+
+/**
+ * Heartbeat: mantiene `last_seen_at` vivo en el servidor y refresca la
+ * configuración de reconocimiento facial (umbral/gap) usada por el matcher local.
+ * @returns {Promise<void>}
+ */
+export async function heartbeat() {
+    try {
+        const data = await apiFetch('/heartbeat', { method: 'POST' });
+        if (!data.ok) throw new Error(data.message || 'Error en heartbeat');
+
+        await setMeta('face_threshold', data.config.face_threshold);
+        await setMeta('face_min_confidence_gap', data.config.face_min_confidence_gap);
+        await setMeta('server_clock_offset_ms', new Date(data.server_time).getTime() - Date.now());
+        await setMeta('last_heartbeat_at', Date.now());
+
+        await logSync('heartbeat', true);
+    } catch (error) {
+        await logSync('heartbeat', false, error.message);
+        throw error;
+    }
+}
+
+/**
+ * Config de reconocimiento facial vigente (sincronizada vía heartbeat).
+ * @returns {Promise<{threshold: number|null, minGap: number|null}>} null si todavía no hubo un heartbeat exitoso.
+ */
+export async function getFaceConfig() {
+    const threshold = await getMeta('face_threshold');
+    const minGap = await getMeta('face_min_confidence_gap');
+    return { threshold: threshold ?? null, minGap: minGap ?? null };
+}
+
+/**
+ * Estado del día (último evento / eventos permitidos) para un empleado ya
+ * identificado localmente. Requiere red — en esta fase la marcación sigue
+ * siendo síncrona/online, esto no se resuelve desde la caché local todavía.
+ * @param {number} employeeId
+ * @returns {Promise<{last_event: string|null, last_event_time: string|null, allowed_events: string[]}>}
+ */
+export async function fetchEmployeeStatus(employeeId) {
+    const data = await apiFetch(`/employees/${employeeId}/status`);
+    if (!data.ok) throw new Error(data.message || 'No se pudo obtener el estado del empleado.');
+    return data;
+}
+
+/**
+ * Envía un lote de eventos de marcación (hoy siempre de a uno, la cola
+ * offline en lote llega en una fase posterior).
+ * @param {Array<{client_event_id: string, employee_id: number, event_type: string, recorded_at: string, location?: object|null}>} events
+ * @returns {Promise<Array<{client_event_id: string, status: string, event_id?: number, message?: string}>>}
+ */
+export async function submitEvents(events) {
+    const data = await apiFetch('/events/sync', {
+        method: 'POST',
+        body: JSON.stringify({ events }),
+    });
+    if (!data.ok) throw new Error(data.message || 'No se pudo registrar la marcación.');
+    return data.results;
+}

--- a/resources/js/attendances/terminal.js
+++ b/resources/js/attendances/terminal.js
@@ -1,4 +1,7 @@
 import { captureFaceSamples } from '../shared/face-capture-core.js';
+import { migrateTokenFromLocalStorage, getMeta, getCachedEmployees } from './terminal-offline/db.js';
+import { identifyEmployee as matchDescriptor } from './terminal-offline/matcher.js';
+import { heartbeat, syncEmployees, getFaceConfig, fetchEmployeeStatus, submitEvents, TerminalAuthError } from './terminal-offline/sync.js';
 
 document.addEventListener("DOMContentLoaded", () => {
     // ============================================================================
@@ -33,6 +36,8 @@ document.addEventListener("DOMContentLoaded", () => {
     const idStatusDot         = document.getElementById("idStatusDot");
     const idleClock           = document.getElementById("idleClock");
     const idleDate            = document.getElementById("idleDate");
+    const idleSyncStatus      = document.getElementById("idleSyncStatus");
+    const btnForceSync        = document.getElementById("btnForceSync");
 
     const terminalCaptureProgress = document.getElementById("terminalCaptureProgress");
     const terminalCaptureDots     = terminalCaptureProgress
@@ -63,11 +68,6 @@ document.addEventListener("DOMContentLoaded", () => {
 
     // Error screen elements
     const errorMessage = document.getElementById("errorMessage");
-
-    // CSRF Token
-    const csrfToken = document.querySelector("meta[name=csrf-token]");
-    const CSRF = csrfToken ? csrfToken.content : "";
-    if (!CSRF) console.warn("Token CSRF no encontrado.");
 
     const MODELS_URI      = "/models";
     const IDLE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutos sin marcaciones
@@ -104,6 +104,7 @@ document.addEventListener("DOMContentLoaded", () => {
         presenceCheckInterval:  null,
         isIdle:                 false,
         userHasInteracted:      false,  // vibración solo permitida tras gesto del usuario
+        backgroundSyncStarted:  false,  // evita registrar los setInterval de sync más de una vez
     };
 
     const tinyOptions  = new faceapi.TinyFaceDetectorOptions({ inputSize: 416, scoreThreshold: 0.6 });
@@ -411,6 +412,8 @@ document.addEventListener("DOMContentLoaded", () => {
             // Adquirir wake lock para mantener pantalla encendida
             await acquireWakeLock();
 
+            await initializeOfflineSync();
+
             console.log("Sistema inicializado correctamente");
 
             // Mostrar pantalla idle primero — requiere toque para activar audio/vibración
@@ -587,18 +590,55 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     // ============================================================================
-    // IDENTIFICACIÓN
+    // IDENTIFICACIÓN — matching client-side contra la caché local (IndexedDB)
     // ============================================================================
+    /**
+     * Identifica al empleado comparando el descriptor capturado contra la caché
+     * local de empleados (employees_cache), con el mismo algoritmo de distancia
+     * euclidiana + umbral/gap que corre en el servidor (ver terminal-offline/matcher.js).
+     * Solo la consulta de "qué eventos son válidos ahora" (fetchEmployeeStatus)
+     * sigue requiriendo red en esta fase — el reconocimiento en sí ya no depende
+     * del servidor.
+     */
     async function identifyEmployee(descriptor) {
         try {
-            const response = await fetch("/marcar/identificar", {
-                method: "POST",
-                headers: { "Content-Type": "application/json", "X-CSRF-TOKEN": CSRF },
-                body: JSON.stringify({ face_descriptor: descriptor, source: "terminal" }),
-            });
-            if (response.status === 419) return { ok: false, is419: true };
-            return await response.json();
+            const { threshold, minGap } = await getFaceConfig();
+            if (threshold == null || minGap == null) {
+                return { ok: false, message: "Terminal sincronizando por primera vez, espere un momento." };
+            }
+
+            const candidates = await getCachedEmployees();
+            const { employee, distance, reason } = matchDescriptor(descriptor, candidates, threshold, minGap);
+
+            if (!employee) {
+                const messages = {
+                    no_candidates: "No hay empleados sincronizados en este terminal.",
+                    ambiguous: "Rostro ambiguo. Por favor, reposicione su cara e intente de nuevo.",
+                    no_match: "No se pudo identificar el rostro. Intente nuevamente.",
+                };
+                return { ok: false, message: messages[reason] || "No identificado", reason };
+            }
+
+            const status = await fetchEmployeeStatus(employee.id);
+
+            return {
+                ok: true,
+                employee: {
+                    id: employee.id,
+                    first_name: employee.first_name,
+                    last_name: employee.last_name,
+                    ci: employee.ci,
+                    photo_url: "/images/default-avatar.png", // la caché offline no incluye fotos (ver EmployeeDescriptorSyncService)
+                },
+                distance,
+                last_event: status.last_event,
+                last_event_time: status.last_event_time,
+                allowed_events: status.allowed_events,
+            };
         } catch (error) {
+            if (error instanceof TerminalAuthError) {
+                return { ok: false, message: error.message, needsProvisioning: true };
+            }
             console.error("Error en identificación:", error);
             return { ok: false, message: "Error de conexión" };
         }
@@ -637,10 +677,10 @@ document.addEventListener("DOMContentLoaded", () => {
 
                 const result = await identifyEmployee(descriptor);
 
-                if (result.is419) {
+                if (result.needsProvisioning) {
                     stopAutoIdentification();
                     await finishCaptureProgress("error");
-                    showError("La sesión ha caducado. Recargue la página para continuar.");
+                    showError(result.message);
                     return;
                 }
 
@@ -727,38 +767,36 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     // ============================================================================
-    // REGISTRO DE MARCACIÓN
+    // REGISTRO DE MARCACIÓN — vía la API de sincronización (Sanctum)
     // ============================================================================
+    /**
+     * Envía la marcación a /api/v1/terminal/events/sync con un client_event_id
+     * generado en el momento de la captura (deduplica reintentos con seguridad).
+     * En esta fase el envío sigue siendo síncrono/en línea — la cola de eventos
+     * offline (para cuando falla por falta de red) llega en una fase posterior.
+     */
     async function registerMark(employee, eventType) {
         try {
             updateStatus("Registrando marcación...", "loading");
 
-            const response = await fetch("/marcar", {
-                method: "POST",
-                headers: { "Content-Type": "application/json", "X-CSRF-TOKEN": CSRF },
-                body: JSON.stringify({
-                    employee_id:   employee.id,
-                    event_type:    eventType,
-                    source:        "terminal",
-                    ...(terminalData ? { terminal_code: terminalData.code } : {}),
-                }),
-            });
+            const recordedAt = new Date().toISOString();
+            const results = await submitEvents([{
+                client_event_id: crypto.randomUUID(),
+                employee_id: employee.id,
+                event_type: eventType,
+                recorded_at: recordedAt,
+            }]);
 
-            if (response.status === 419) {
-                showError("La sesión ha caducado. Recargue la página para continuar.");
-                return;
-            }
+            const result = results?.[0];
 
-            const data = await response.json();
-
-            if (data.ok) {
-                showSuccessScreen(employee, data.data, eventType);
+            if (result?.status === "synced" || result?.status === "duplicate") {
+                showSuccessScreen(employee, { event_id: result.event_id, recorded_at: recordedAt }, eventType);
             } else {
-                showError(data.message || "No se pudo registrar la marcación.");
+                showError(result?.message || "No se pudo registrar la marcación.");
             }
         } catch (error) {
             console.error("Error al registrar marcación:", error);
-            showError("Error de conexión al registrar la marcación.");
+            showError(error instanceof TerminalAuthError ? error.message : "Error de conexión al registrar la marcación.");
         }
     }
 
@@ -989,6 +1027,86 @@ document.addEventListener("DOMContentLoaded", () => {
     };
     document.addEventListener("click",      markInteraction, { once: true });
     document.addEventListener("touchstart", markInteraction, { once: true });
+
+    // ============================================================================
+    // SINCRONIZACIÓN OFFLINE — token, caché de empleados y config facial
+    // ============================================================================
+    function updateIdleSyncStatus(text) {
+        if (idleSyncStatus) idleSyncStatus.textContent = text;
+    }
+
+    /**
+     * Migra el token de configuración (si venía de localStorage, ver
+     * terminal-setup.blade.php) y hace la primera sincronización antes de
+     * arrancar el reposo. Si el terminal no está provisionado, no bloquea el
+     * arranque — solo informa en la pantalla idle, la auto-identificación
+     * fallará limpiamente con "terminal sin configurar" hasta que se resuelva.
+     */
+    async function initializeOfflineSync() {
+        await migrateTokenFromLocalStorage();
+        const token = await getMeta("api_token");
+
+        if (!token) {
+            console.warn("Terminal sin token de sincronización — falta provisión.");
+            updateIdleSyncStatus("Terminal sin configurar");
+            return;
+        }
+
+        try {
+            updateIdleSyncStatus("Sincronizando...");
+            await heartbeat();
+            const result = await syncEmployees();
+            updateIdleSyncStatus(`Sincronizado — ${result.employees ? "actualizado" : "sin cambios"}`);
+        } catch (error) {
+            console.warn("Sincronización inicial falló (se reintentará en segundo plano):", error.message);
+            updateIdleSyncStatus(navigator.onLine ? "Error al sincronizar" : "Sin conexión — usando datos locales");
+        }
+
+        startBackgroundSync();
+    }
+
+    /** Heartbeat + sync de empleados periódicos mientras haya conexión, más un intento al recuperarla. */
+    function startBackgroundSync() {
+        if (terminalState.backgroundSyncStarted) return;
+        terminalState.backgroundSyncStarted = true;
+
+        const runHeartbeat = () => {
+            if (!navigator.onLine) return;
+            heartbeat().catch((error) => console.warn("Heartbeat en segundo plano falló:", error.message));
+        };
+        const runEmployeeSync = () => {
+            if (!navigator.onLine) return;
+            syncEmployees()
+                .then((result) => updateIdleSyncStatus(`Sincronizado — ${result.employees} empleados`))
+                .catch((error) => console.warn("Sync de empleados en segundo plano falló:", error.message));
+        };
+
+        setInterval(runHeartbeat, 90 * 1000);
+        setInterval(runEmployeeSync, 5 * 60 * 1000);
+
+        window.addEventListener("online", () => {
+            runHeartbeat();
+            runEmployeeSync();
+        });
+    }
+
+    // Botón "Forzar sincronización" en la pantalla de reposo
+    if (btnForceSync) {
+        btnForceSync.addEventListener("click", async (event) => {
+            event.stopPropagation(); // no disparar exitIdle() (despertaría la cámara sin necesidad)
+            btnForceSync.disabled = true;
+            updateIdleSyncStatus("Sincronizando...");
+            try {
+                await heartbeat();
+                const result = await syncEmployees();
+                updateIdleSyncStatus(`Sincronizado — ${result.employees} empleados`);
+            } catch (error) {
+                updateIdleSyncStatus(error instanceof TerminalAuthError ? "Terminal sin configurar" : "Error al sincronizar");
+            } finally {
+                btnForceSync.disabled = false;
+            }
+        });
+    }
 
     // ============================================================================
     // TEMA CLARO / OSCURO

--- a/resources/views/components/attendance/terminal-idle.blade.php
+++ b/resources/views/components/attendance/terminal-idle.blade.php
@@ -7,6 +7,16 @@
                 <span id="idleTerminalName"></span>
                 <span id="idleTerminalBranch"></span>
             </div>
+            <div class="idle-sync-row">
+                <span class="idle-sync-status" id="idleSyncStatus" aria-live="polite"></span>
+                <button
+                    type="button"
+                    id="btnForceSync"
+                    class="terminal-btn terminal-btn-ghost idle-sync-btn"
+                    aria-label="Forzar sincronización de empleados">
+                    Sincronizar
+                </button>
+            </div>
         </div>
         <div class="idle-hint">
             <span class="idle-hint-dot" aria-hidden="true"></span>

--- a/routes/api.php
+++ b/routes/api.php
@@ -22,6 +22,10 @@ Route::prefix('v1/terminal')->name('api.terminal.')->middleware(['auth:sanctum']
         ->middleware('ability:terminal:sync')
         ->name('employees.sync');
 
+    Route::get('/employees/{employee}/status', [TerminalEmployeeSyncController::class, 'status'])
+        ->middleware('ability:terminal:sync')
+        ->name('employees.status');
+
     Route::post('/events/sync', [TerminalEventSyncController::class, 'store'])
         ->middleware('ability:terminal:sync')
         ->name('events.sync');


### PR DESCRIPTION
## Summary

Tercer paso de la marcación offline vía PWA (Fase 1 — API Sanctum — #77, Fase 2 — service worker — #78). El kiosko ahora identifica al empleado comparando el descriptor facial contra una caché local en IndexedDB, en vez de consultar al servidor — **el reconocimiento facial en sí ya no depende de la red**. El envío de la marcación y la consulta de qué eventos son válidos para ese empleado todavía requieren conexión síncrona; resolver eso offline es la Fase 4 (cola de eventos).

- Nueva dependencia `idb`. Nuevo módulo `resources/js/attendances/terminal-offline/`:
  - `db.js` — IndexedDB (`nominapp-terminal`) con los 4 stores planeados (`terminal_meta`, `employees_cache`, `outbound_events`, `sync_log` — los dos últimos ya creados aunque recién se usan en la Fase 4, para no requerir otro bump de versión). Migra una sola vez el token que `terminal-setup.blade.php` (Fase 1) dejaba en `localStorage`.
  - `matcher.js` — port a JS de `AttendanceFaceMarkController::identifyEmployeeByDescriptor()` (distancia euclidiana + umbral + gap de confianza).
  - `sync.js` — cliente de `/api/v1/terminal/*`: delta de empleados, heartbeat (refresca `face_threshold`/`face_min_confidence_gap`), estado del empleado, envío de eventos.
- **Nuevo `GET /api/v1/terminal/employees/{employee}/status`** — no estaba en el plan original de la Fase 3; hizo falta porque al mover el matching al cliente se perdió el cálculo server-side de "último evento / eventos permitidos" que antes venía junto con `/marcar/identificar`.
- **Fix**: `AttendanceEventSyncService::insertEvent()` (Fase 1) no tenía el fallback a coordenadas de sucursal cuando el kiosko no manda GPS — comportamiento que sí tiene el controller original. Agregado con el mismo criterio.
- `terminal.js` converge completamente a la API Sanctum (ya no usa CSRF/sesión para nada). Sync en segundo plano (heartbeat cada 90s, empleados cada 5min, más al recuperar conexión) y botón manual "Sincronizar" en la pantalla de reposo.

### Conocido, no resuelto en esta fase

El avatar del empleado en la pantalla de éxito ahora muestra un ícono genérico en vez de la foto real — la caché offline de empleados no incluye fotos (decisión de la Fase 1, para no inflar el payload de sync). Mejora futura posible, no bloqueante.

## Test plan

- [x] Casos unitarios de `matcher.js` corridos directo en Node: match perfecto, no_match, ambiguous, match claro con gap suficiente, sin candidatos.
- [x] End-to-end con Playwright (Chromium real) contra un servidor Laravel real:
  - Terminal sin provisionar → muestra "Terminal sin configurar", sin errores.
  - Terminal provisionado → migra el token de `localStorage` a IndexedDB, sincroniza `employees_cache` (empleados con descriptor de 128 elementos) y la config facial coincide con `GeneralSettings` del servidor.
  - Botón manual "Sincronizar" funciona y no despierta la cámara (`stopPropagation`).
- [x] Verificación por curl del nuevo endpoint `/employees/{id}/status` (antes/después de marcar) y del fallback de ubicación (coincide con las coordenadas de la sucursal).
- [x] `vendor/bin/pint --dirty` sin cambios pendientes; `npm run build` sin errores.
- [ ] Nota: un patrón de query ya existente en el proyecto (`AttendanceDay::where('date', $today)`) no matchea contra mi esquema de prueba en SQLite por diferencias de normalización de columnas `DATE` vs MySQL — confirmé que el patrón pre-existente (`AttendanceFaceMarkController::identify()`) falla exactamente igual en ese mismo entorno, así que es un artefacto del entorno de test, no un bug nuevo. Igual, vale confirmar el endpoint de status contra un MySQL real antes de dar la fase por cerrada.
- [ ] Prueba manual en un kiosko/navegador real con cámara: identificar a un empleado sincronizado y confirmar que aparece la pantalla de selección/marcación correcta.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH)_