### PR TITLE
Agregar cola de eventos offline al kiosko de terminal (Fase 4)

### DIFF
--- a/app/Models/AttendanceMarkFailure.php
+++ b/app/Models/AttendanceMarkFailure.php
@@ -28,8 +28,8 @@ class AttendanceMarkFailure extends Model
     ];
 
     protected $casts = [
-        'metadata'    => 'array',
-        'location'    => 'array',
+        'metadata' => 'array',
+        'location' => 'array',
         'occurred_at' => 'datetime',
     ];
 
@@ -55,75 +55,65 @@ class AttendanceMarkFailure extends Model
 
     /**
      * Retorna el label legible del tipo de fallo.
-     *
-     * @param  string $type
-     * @return string
      */
     public static function getFailureTypeLabel(string $type): string
     {
         return match ($type) {
-            'face_no_match'          => 'Rostro no reconocido',
-            'face_ambiguous'         => 'Rostro ambiguo',
-            'face_no_candidates'     => 'Sin empleados enrolados',
-            'face_invalid_descriptor'=> 'Descriptor facial inválido',
-            'employee_not_found'     => 'Empleado no encontrado',
-            'employee_inactive'      => 'Empleado inactivo',
-            'employee_no_branch'     => 'Sin sucursal asignada',
-            'branch_no_coordinates'  => 'Sucursal sin coordenadas',
+            'face_no_match' => 'Rostro no reconocido',
+            'face_ambiguous' => 'Rostro ambiguo',
+            'face_no_candidates' => 'Sin empleados enrolados',
+            'face_invalid_descriptor' => 'Descriptor facial inválido',
+            'employee_not_found' => 'Empleado no encontrado',
+            'employee_inactive' => 'Empleado inactivo',
+            'employee_no_branch' => 'Sin sucursal asignada',
+            'branch_no_coordinates' => 'Sucursal sin coordenadas',
             'invalid_event_sequence' => 'Secuencia de evento inválida',
-            'invalid_location'       => 'Ubicación inválida',
-            'internal_error'         => 'Error interno',
-            default                  => $type,
+            'invalid_location' => 'Ubicación inválida',
+            'internal_error' => 'Error interno',
+            'sync_conflict' => 'Conflicto al sincronizar (offline)',
+            default => $type,
         };
     }
 
     /**
      * Retorna el color del badge según el tipo de fallo.
-     *
-     * @param  string $type
-     * @return string
      */
     public static function getFailureTypeColor(string $type): string
     {
         return match ($type) {
-            'face_no_match', 'face_ambiguous'       => 'warning',
-            'face_no_candidates', 'internal_error'  => 'danger',
+            'face_no_match', 'face_ambiguous' => 'warning',
+            'face_no_candidates', 'internal_error' => 'danger',
             'employee_not_found', 'employee_inactive' => 'danger',
             'employee_no_branch', 'branch_no_coordinates' => 'warning',
-            'invalid_event_sequence'                => 'info',
-            'invalid_location'                      => 'warning',
-            'face_invalid_descriptor'               => 'gray',
-            default                                 => 'gray',
+            'invalid_event_sequence' => 'info',
+            'invalid_location' => 'warning',
+            'face_invalid_descriptor' => 'gray',
+            'sync_conflict' => 'danger',
+            default => 'gray',
         };
     }
 
     /**
      * Retorna el label del modo de marcación.
-     *
-     * @param  string $mode
-     * @return string
      */
     public static function getModeLabel(string $mode): string
     {
         return match ($mode) {
             'terminal' => 'Terminal',
-            'mobile'   => 'Móvil',
-            default    => 'Desconocido',
+            'mobile' => 'Móvil',
+            default => 'Desconocido',
         };
     }
 
     /**
      * Retorna el color del badge según el modo.
-     *
-     * @param  string $mode
-     * @return string
      */
     public static function getModeColor(string $mode): string
     {
         return match ($mode) {
             'terminal' => 'info',
-            'mobile'   => 'success',
-            default    => 'gray',
+            'mobile' => 'success',
+            default => 'gray',
         };
     }
 
@@ -135,25 +125,25 @@ class AttendanceMarkFailure extends Model
     public static function getFailureTypeOptions(): array
     {
         return [
-            'face_no_match'           => 'Rostro no reconocido',
-            'face_ambiguous'          => 'Rostro ambiguo',
-            'face_no_candidates'      => 'Sin empleados enrolados',
+            'face_no_match' => 'Rostro no reconocido',
+            'face_ambiguous' => 'Rostro ambiguo',
+            'face_no_candidates' => 'Sin empleados enrolados',
             'face_invalid_descriptor' => 'Descriptor facial inválido',
-            'employee_not_found'      => 'Empleado no encontrado',
-            'employee_inactive'       => 'Empleado inactivo',
-            'employee_no_branch'      => 'Sin sucursal asignada',
-            'branch_no_coordinates'   => 'Sucursal sin coordenadas',
-            'invalid_event_sequence'  => 'Secuencia de evento inválida',
-            'invalid_location'        => 'Ubicación inválida',
-            'internal_error'          => 'Error interno',
+            'employee_not_found' => 'Empleado no encontrado',
+            'employee_inactive' => 'Empleado inactivo',
+            'employee_no_branch' => 'Sin sucursal asignada',
+            'branch_no_coordinates' => 'Sucursal sin coordenadas',
+            'invalid_event_sequence' => 'Secuencia de evento inválida',
+            'invalid_location' => 'Ubicación inválida',
+            'internal_error' => 'Error interno',
+            'sync_conflict' => 'Conflicto al sincronizar (offline)',
         ];
     }
 
     /**
      * Crea y persiste un registro de fallo de marcación.
      *
-     * @param  array<string, mixed> $data
-     * @return static
+     * @param  array<string, mixed>  $data
      */
     public static function record(array $data): static
     {

--- a/app/Services/AttendanceEventSyncService.php
+++ b/app/Services/AttendanceEventSyncService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Models\AttendanceDay;
 use App\Models\AttendanceEvent;
+use App\Models\AttendanceMarkFailure;
 use App\Models\Employee;
 use App\Models\Terminal;
 use Carbon\Carbon;
@@ -69,6 +70,11 @@ class AttendanceEventSyncService
         $clientEventId = $eventData['client_event_id'];
 
         if (! $employee) {
+            $this->recordSyncFailure($terminal, 'employee_not_found', 'Empleado no encontrado o inactivo al sincronizar marcación offline.', [
+                'client_event_id' => $clientEventId,
+                'attempted_employee_id' => $eventData['employee_id'] ?? null,
+            ]);
+
             return [
                 'client_event_id' => $clientEventId,
                 'status' => 'rejected',
@@ -149,6 +155,20 @@ class AttendanceEventSyncService
                 'allowed_events' => $allowed,
             ]);
 
+            $this->recordSyncFailure(
+                $terminal,
+                'sync_conflict',
+                'La secuencia de marcación ya no es válida en el servidor al sincronizar (último evento registrado: '.($last->event_type ?? 'ninguno').').',
+                [
+                    'client_event_id' => $clientEventId,
+                    'attempted_event' => $eventData['event_type'],
+                    'last_event' => $last?->event_type,
+                    'allowed_events' => $allowed,
+                ],
+                $employee,
+                $eventData['event_type'],
+            );
+
             return [
                 'client_event_id' => $clientEventId,
                 'status' => 'conflict',
@@ -181,6 +201,41 @@ class AttendanceEventSyncService
             'status' => 'synced',
             'event_id' => $event->id,
         ];
+    }
+
+    /**
+     * Persiste un intento fallido de sincronización para revisión en Filament
+     * (AttendanceMarkFailureResource) — mismo patrón que
+     * AttendanceFaceMarkController::recordFailure(), pero sin Request (esta
+     * capa corre en background/batch, no hay IP de un usuario final que registrar).
+     *
+     * @param  array<string, mixed>  $metadata
+     */
+    private function recordSyncFailure(
+        Terminal $terminal,
+        string $failureType,
+        string $message,
+        array $metadata = [],
+        ?Employee $employee = null,
+        ?string $eventType = null,
+    ): void {
+        try {
+            AttendanceMarkFailure::record([
+                'mode' => 'terminal',
+                'failure_type' => $failureType,
+                'employee_id' => $employee?->id,
+                'branch_id' => $terminal->branch_id,
+                'attempted_event_type' => $eventType,
+                'failure_message' => $message,
+                'metadata' => ! empty($metadata) ? $metadata : null,
+            ]);
+        } catch (Throwable $e) {
+            Log::error('No se pudo persistir el fallo de sincronización offline', [
+                'failure_type' => $failureType,
+                'terminal_id' => $terminal->id,
+                'error' => $e->getMessage(),
+            ]);
+        }
     }
 
     /**

--- a/resources/css/attendances/terminal.css
+++ b/resources/css/attendances/terminal.css
@@ -788,6 +788,18 @@ html[data-theme="dark"]  .theme-toggle .icon-moon { display: none; }
 .auto-close-message { font-size: .8rem; color: var(--c-subtle); margin-bottom: var(--sp-4); }
 #countdown { font-weight: 700; color: var(--c-primary); }
 
+/* Aviso de marcación guardada offline (sin confirmar todavía con el servidor) */
+.success-queued-notice {
+    font-size: .75rem;
+    font-weight: 600;
+    color: var(--c-warning);
+    background: var(--c-warning-bg);
+    border: 1px solid var(--c-warning-ring);
+    border-radius: var(--r-md, .5rem);
+    padding: var(--sp-2, .5rem) var(--sp-3, .75rem);
+    margin-bottom: var(--sp-4);
+}
+
 .error-message {
     font-size: clamp(.875rem, 2vw, 1.0625rem);
     color: var(--c-muted); line-height: 1.6;

--- a/resources/js/attendances/terminal-offline/db.js
+++ b/resources/js/attendances/terminal-offline/db.js
@@ -4,25 +4,29 @@
  * =============================================================================
  *
  * @fileoverview Wrapper delgado sobre `idb` para la base local del kiosko.
- *               Se crean los 4 stores de una vez (aunque `outbound_events` y
- *               `sync_log` recién se usan a partir de fases posteriores) para
- *               no requerir un bump de versión de IndexedDB más adelante.
  *
  * Stores:
- * - terminal_meta   — key/value: api_token, terminal_id/code/branch_id,
- *                      cursores de sync, config de reconocimiento facial.
- * - employees_cache — keyPath 'id': empleados activos con descriptor facial,
- *                      scopeados a la sucursal del terminal (ver sync.js).
- * - outbound_events — keyPath 'client_event_id': cola de marcaciones
- *                      pendientes de sincronizar (fase de cola offline).
- * - sync_log        — autoIncrement: historial breve de intentos de sync,
- *                      para diagnóstico en pantalla.
+ * - terminal_meta          — key/value: api_token, terminal_id/code/branch_id,
+ *                             cursores de sync, config de reconocimiento facial.
+ * - employees_cache        — keyPath 'id': empleados activos con descriptor
+ *                             facial, scopeados a la sucursal del terminal.
+ * - outbound_events        — keyPath 'client_event_id': cola de marcaciones
+ *                             capturadas localmente. `status`: 'pending'
+ *                             (por sincronizar) | 'conflict' (el servidor la
+ *                             rechazó — no se reintenta, queda para revisión).
+ *                             Las sincronizadas con éxito se eliminan del store.
+ * - employee_status_cache  — keyPath 'employee_id': último estado de marcación
+ *                             conocido del servidor (last_event/allowed_events)
+ *                             por empleado, para poder resolver localmente qué
+ *                             botones mostrar cuando no hay red (ver queue.js).
+ * - sync_log               — autoIncrement: historial breve de intentos de
+ *                             sync, para diagnóstico en pantalla.
  */
 
 import { openDB } from 'idb';
 
 const DB_NAME = 'nominapp-terminal';
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 
 /** @type {Promise<import('idb').IDBPDatabase>|null} */
 let dbPromise = null;
@@ -40,6 +44,9 @@ export function getDb() {
                 }
                 if (!db.objectStoreNames.contains('outbound_events')) {
                     db.createObjectStore('outbound_events', { keyPath: 'client_event_id' });
+                }
+                if (!db.objectStoreNames.contains('employee_status_cache')) {
+                    db.createObjectStore('employee_status_cache', { keyPath: 'employee_id' });
                 }
                 if (!db.objectStoreNames.contains('sync_log')) {
                     db.createObjectStore('sync_log', { keyPath: 'id', autoIncrement: true });
@@ -130,4 +137,95 @@ export async function applyEmployeesDelta(employees, tombstones) {
         await tx.store.delete(id);
     }
     await tx.done;
+}
+
+// =========================================================================
+// COLA DE EVENTOS OFFLINE (outbound_events)
+// =========================================================================
+
+/**
+ * Encola una marcación capturada localmente. `date` es la fecha local del
+ * dispositivo (YYYY-MM-DD) al momento de la captura — se usa solo para
+ * filtrar "eventos de hoy de este empleado" del lado del cliente; la fecha
+ * real de negocio (con el timezone de la app) la decide el servidor al sincronizar.
+ * @param {{client_event_id: string, employee_id: number, event_type: string, recorded_at: string, date: string}} event
+ */
+export async function queueEvent(event) {
+    const db = await getDb();
+    await db.put('outbound_events', { ...event, status: 'pending', attempts: 0, created_at: Date.now() });
+}
+
+/** @returns {Promise<Array<object>>} Eventos pendientes de sincronizar (no incluye los marcados 'conflict'). */
+export async function getPendingEvents() {
+    const db = await getDb();
+    const all = await db.getAll('outbound_events');
+    return all.filter((event) => event.status === 'pending');
+}
+
+/**
+ * Eventos (pendientes o en conflicto) de un empleado para la fecha local
+ * indicada — usado para resolver localmente el último evento del día
+ * cuando no hay red para consultar al servidor (ver queue.js).
+ * @param {number} employeeId
+ * @param {string} date - YYYY-MM-DD local.
+ */
+export async function getEventsForEmployeeOnDate(employeeId, date) {
+    const db = await getDb();
+    const all = await db.getAll('outbound_events');
+    return all.filter((event) => event.employee_id === employeeId && event.date === date);
+}
+
+/** Marca un evento encolado como sincronizado — se elimina del store (ya vive en el servidor). */
+export async function removeQueuedEvent(clientEventId) {
+    const db = await getDb();
+    await db.delete('outbound_events', clientEventId);
+}
+
+/** Marca un evento encolado como rechazado por el servidor — no se reintenta más, queda para revisión manual. */
+export async function markQueuedEventConflict(clientEventId, message) {
+    const db = await getDb();
+    const event = await db.get('outbound_events', clientEventId);
+    if (!event) return;
+    await db.put('outbound_events', { ...event, status: 'conflict', server_message: message ?? null });
+}
+
+/** Incrementa el contador de intentos de un evento encolado (diagnóstico, no afecta el reintento en sí). */
+export async function incrementQueuedEventAttempts(clientEventId) {
+    const db = await getDb();
+    const event = await db.get('outbound_events', clientEventId);
+    if (!event) return;
+    await db.put('outbound_events', { ...event, attempts: (event.attempts ?? 0) + 1 });
+}
+
+/** @returns {Promise<number>} Cantidad de eventos pendientes de sincronizar. */
+export async function countPendingEvents() {
+    return (await getPendingEvents()).length;
+}
+
+/** @returns {Promise<number>} Cantidad de eventos en conflicto (requieren revisión manual en Filament). */
+export async function countConflictEvents() {
+    const db = await getDb();
+    const all = await db.getAll('outbound_events');
+    return all.filter((event) => event.status === 'conflict').length;
+}
+
+// =========================================================================
+// CACHÉ DE ESTADO POR EMPLEADO (employee_status_cache)
+// =========================================================================
+
+/**
+ * Guarda el último estado de marcación conocido del servidor para un
+ * empleado (se actualiza cada vez que fetchEmployeeStatus() tiene éxito).
+ * @param {number} employeeId
+ * @param {{last_event: string|null, last_event_time: string|null, allowed_events: string[]}} status
+ */
+export async function setEmployeeStatusCache(employeeId, status) {
+    const db = await getDb();
+    await db.put('employee_status_cache', { employee_id: employeeId, ...status, cached_at: Date.now() });
+}
+
+/** @param {number} employeeId @returns {Promise<object|undefined>} */
+export async function getEmployeeStatusCache(employeeId) {
+    const db = await getDb();
+    return db.get('employee_status_cache', employeeId);
 }

--- a/resources/js/attendances/terminal-offline/queue.js
+++ b/resources/js/attendances/terminal-offline/queue.js
@@ -1,0 +1,192 @@
+/**
+ * =============================================================================
+ * COLA DE EVENTOS OFFLINE
+ * =============================================================================
+ *
+ * @fileoverview Orquesta la captura, resolución de estado y sincronización en
+ *               segundo plano de las marcaciones del kiosko. A diferencia de
+ *               la Fase 3 (matching client-side, pero marcación aún síncrona),
+ *               acá el envío puede diferirse: toda marcación se guarda primero
+ *               en `outbound_events` (durable) y recién después se intenta
+ *               sincronizar — si falla por falta de red, queda en cola para
+ *               el próximo intento (background o al reconectar).
+ */
+
+import {
+    queueEvent,
+    getPendingEvents,
+    getEventsForEmployeeOnDate,
+    removeQueuedEvent,
+    markQueuedEventConflict,
+    incrementQueuedEventAttempts,
+    countPendingEvents,
+    countConflictEvents,
+    getEmployeeStatusCache,
+    setEmployeeStatusCache,
+} from './db.js';
+import { submitEvents, fetchEmployeeStatus } from './sync.js';
+
+/**
+ * Máquina de estados de marcación diaria — mismo criterio que
+ * AttendanceEvent::allowedNextEventTypes() en el backend. Se necesita acá
+ * (además de en el servidor) para poder resolver localmente qué botones
+ * mostrar cuando no hay red para preguntarle al servidor.
+ * @param {string|null} lastEventType
+ * @returns {string[]}
+ */
+export function allowedNextEventTypes(lastEventType) {
+    switch (lastEventType) {
+        case null:
+        case undefined:
+            return ['check_in'];
+        case 'check_in':
+            return ['break_start', 'check_out'];
+        case 'break_start':
+            return ['break_end'];
+        case 'break_end':
+            return ['break_start', 'check_out'];
+        case 'check_out':
+            return [];
+        default:
+            return ['check_in'];
+    }
+}
+
+/** @returns {string} Fecha local del dispositivo en formato YYYY-MM-DD. */
+function localDateString(date = new Date()) {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+}
+
+/**
+ * Resuelve el estado de marcación de un empleado para hoy, combinando:
+ * 1) el último estado que el servidor confirmó (cacheado en la última
+ *    consulta online exitosa), con
+ * 2) los eventos que este mismo kiosko ya encoló hoy para ese empleado pero
+ *    el servidor todavía no confirmó — para no repetir ni saltear pasos
+ *    mientras está offline.
+ * @param {number} employeeId
+ * @returns {Promise<{last_event: string|null, last_event_time: string|null, allowed_events: string[]}>}
+ */
+export async function resolveEmployeeStatus(employeeId) {
+    const cached = await getEmployeeStatusCache(employeeId);
+    const today = localDateString();
+    const localEvents = (await getEventsForEmployeeOnDate(employeeId, today))
+        .filter((event) => event.status === 'pending') // los en conflicto no cuentan como "ya registrados"
+        .sort((a, b) => a.recorded_at.localeCompare(b.recorded_at));
+
+    let lastEvent = cached?.last_event ?? null;
+    let lastEventTime = cached?.last_event_time ?? null;
+
+    for (const event of localEvents) {
+        lastEvent = event.event_type;
+        lastEventTime = new Date(event.recorded_at).toTimeString().slice(0, 5);
+    }
+
+    return {
+        last_event: lastEvent,
+        last_event_time: lastEventTime,
+        allowed_events: allowedNextEventTypes(lastEvent),
+    };
+}
+
+/**
+ * Estado de marcación de un empleado ya identificado localmente: intenta la
+ * consulta en línea (y cachea el resultado para uso offline futuro); si falla
+ * por falta de red, cae a resolveEmployeeStatus() con lo que el kiosko ya sabe.
+ * @param {number} employeeId
+ */
+export async function getEmployeeStatus(employeeId) {
+    try {
+        const status = await fetchEmployeeStatus(employeeId);
+        await setEmployeeStatusCache(employeeId, status);
+        return status;
+    } catch (error) {
+        console.warn(`No se pudo consultar el estado en línea del empleado ${employeeId}, usando estado local:`, error.message);
+        return resolveEmployeeStatus(employeeId);
+    }
+}
+
+/**
+ * Encola una marcación capturada localmente. Debe llamarse ANTES de intentar
+ * sincronizar — así la marcación queda a salvo aunque el envío falle o la
+ * pestaña se cierre a mitad de camino.
+ * @param {number} employeeId
+ * @param {string} eventType
+ * @returns {Promise<{client_event_id: string, recorded_at: string}>}
+ */
+export async function enqueueMark(employeeId, eventType) {
+    const clientEventId = crypto.randomUUID();
+    const recordedAt = new Date();
+
+    await queueEvent({
+        client_event_id: clientEventId,
+        employee_id: employeeId,
+        event_type: eventType,
+        recorded_at: recordedAt.toISOString(),
+        date: localDateString(recordedAt),
+    });
+
+    return { client_event_id: clientEventId, recorded_at: recordedAt.toISOString() };
+}
+
+/** @type {boolean} Evita que dos flush corran en simultáneo (ej. click manual + timer de fondo). */
+let flushInProgress = false;
+
+/**
+ * Intenta sincronizar todos los eventos pendientes en un solo lote. Los
+ * `synced`/`duplicate` se eliminan de la cola; los `conflict`/`rejected` se
+ * marcan como tal (no se reintentan más) para revisión manual en Filament.
+ * Si la red falla directamente (ni siquiera hay respuesta), todos quedan
+ * `pending` para el próximo intento.
+ *
+ * Devuelve `results` (la respuesta cruda del servidor, una entrada por
+ * `client_event_id`) para que el caller pueda saber qué pasó específicamente
+ * con SU evento cuando encoló varios a la vez con otros ya pendientes.
+ * @returns {Promise<{synced: number, conflicts: number, stillPending: number, results: Array<object>}>}
+ */
+export async function flushQueue() {
+    if (flushInProgress) return { synced: 0, conflicts: 0, stillPending: await countPendingEvents(), results: [] };
+    flushInProgress = true;
+
+    try {
+        const pending = await getPendingEvents();
+        if (pending.length === 0) return { synced: 0, conflicts: 0, stillPending: 0, results: [] };
+
+        let results;
+        try {
+            results = await submitEvents(pending.map(({ client_event_id, employee_id, event_type, recorded_at }) => ({
+                client_event_id,
+                employee_id,
+                event_type,
+                recorded_at,
+            })));
+        } catch (error) {
+            // Sin red o el servidor no respondió — todos quedan pendientes, se reintenta después.
+            for (const event of pending) await incrementQueuedEventAttempts(event.client_event_id);
+            console.warn('flushQueue: no se pudo sincronizar (sin red o error de servidor):', error.message);
+            return { synced: 0, conflicts: 0, stillPending: pending.length, results: [] };
+        }
+
+        let synced = 0;
+        let conflicts = 0;
+
+        for (const result of results) {
+            if (result.status === 'synced' || result.status === 'duplicate') {
+                await removeQueuedEvent(result.client_event_id);
+                synced++;
+            } else {
+                await markQueuedEventConflict(result.client_event_id, result.message);
+                conflicts++;
+            }
+        }
+
+        return { synced, conflicts, stillPending: await countPendingEvents(), results };
+    } finally {
+        flushInProgress = false;
+    }
+}
+
+export { countPendingEvents, countConflictEvents };

--- a/resources/js/attendances/terminal-offline/sync.js
+++ b/resources/js/attendances/terminal-offline/sync.js
@@ -117,8 +117,9 @@ export async function fetchEmployeeStatus(employeeId) {
 }
 
 /**
- * Envía un lote de eventos de marcación (hoy siempre de a uno, la cola
- * offline en lote llega en una fase posterior).
+ * Envía un lote de eventos de marcación — uno solo si se llama justo tras
+ * capturar la marcación con red disponible, o varios si se está vaciando la
+ * cola offline acumulada (ver terminal-offline/queue.js).
  * @param {Array<{client_event_id: string, employee_id: number, event_type: string, recorded_at: string, location?: object|null}>} events
  * @returns {Promise<Array<{client_event_id: string, status: string, event_id?: number, message?: string}>>}
  */

--- a/resources/js/attendances/terminal.js
+++ b/resources/js/attendances/terminal.js
@@ -1,7 +1,8 @@
 import { captureFaceSamples } from '../shared/face-capture-core.js';
 import { migrateTokenFromLocalStorage, getMeta, getCachedEmployees } from './terminal-offline/db.js';
 import { identifyEmployee as matchDescriptor } from './terminal-offline/matcher.js';
-import { heartbeat, syncEmployees, getFaceConfig, fetchEmployeeStatus, submitEvents, TerminalAuthError } from './terminal-offline/sync.js';
+import { heartbeat, syncEmployees, getFaceConfig, TerminalAuthError } from './terminal-offline/sync.js';
+import { getEmployeeStatus, enqueueMark, flushQueue, countPendingEvents, countConflictEvents } from './terminal-offline/queue.js';
 
 document.addEventListener("DOMContentLoaded", () => {
     // ============================================================================
@@ -63,6 +64,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const successEmployeeCI   = document.getElementById("successEmployeeCI");
     const successEventType    = document.getElementById("successEventType");
     const successTime         = document.getElementById("successTime");
+    const successQueuedNotice = document.getElementById("successQueuedNotice");
     const countdownEl         = document.getElementById("countdown");
     const countdownFill       = document.getElementById("countdownFill");
 
@@ -596,9 +598,9 @@ document.addEventListener("DOMContentLoaded", () => {
      * Identifica al empleado comparando el descriptor capturado contra la caché
      * local de empleados (employees_cache), con el mismo algoritmo de distancia
      * euclidiana + umbral/gap que corre en el servidor (ver terminal-offline/matcher.js).
-     * Solo la consulta de "qué eventos son válidos ahora" (fetchEmployeeStatus)
-     * sigue requiriendo red en esta fase — el reconocimiento en sí ya no depende
-     * del servidor.
+     * El estado del día (último evento / eventos permitidos) se resuelve vía
+     * getEmployeeStatus(), que intenta la consulta en línea y cae a lo que el
+     * kiosko ya sabe localmente si no hay red — ver terminal-offline/queue.js.
      */
     async function identifyEmployee(descriptor) {
         try {
@@ -619,7 +621,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 return { ok: false, message: messages[reason] || "No identificado", reason };
             }
 
-            const status = await fetchEmployeeStatus(employee.id);
+            const status = await getEmployeeStatus(employee.id);
 
             return {
                 ok: true,
@@ -767,37 +769,48 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     // ============================================================================
-    // REGISTRO DE MARCACIÓN — vía la API de sincronización (Sanctum)
+    // REGISTRO DE MARCACIÓN — cola offline + sync
     // ============================================================================
     /**
-     * Envía la marcación a /api/v1/terminal/events/sync con un client_event_id
-     * generado en el momento de la captura (deduplica reintentos con seguridad).
-     * En esta fase el envío sigue siendo síncrono/en línea — la cola de eventos
-     * offline (para cuando falla por falta de red) llega en una fase posterior.
+     * Encola la marcación en IndexedDB (durable — sobrevive un cierre de
+     * pestaña o un corte de luz) y de inmediato intenta sincronizarla. Si hay
+     * red, el empleado ve la confirmación normal. Si no la hay (o el envío
+     * falla), la marcación NO se pierde — queda en la cola y se reintenta
+     * solo en segundo plano — se le muestra una pantalla de éxito igual,
+     * aclarando que se sincronizará más tarde, para no asustar al empleado
+     * con un error cuando en realidad ya se guardó.
      */
     async function registerMark(employee, eventType) {
+        updateStatus("Registrando marcación...", "loading");
+
+        const { client_event_id: clientEventId, recorded_at: recordedAt } = await enqueueMark(employee.id, eventType);
+
+        if (!navigator.onLine) {
+            showSuccessScreen(employee, { recorded_at: recordedAt }, eventType, { queued: true });
+            await refreshIdleSyncStatus();
+            return;
+        }
+
         try {
-            updateStatus("Registrando marcación...", "loading");
+            const { results } = await flushQueue();
+            const ownResult = results.find((r) => r.client_event_id === clientEventId);
 
-            const recordedAt = new Date().toISOString();
-            const results = await submitEvents([{
-                client_event_id: crypto.randomUUID(),
-                employee_id: employee.id,
-                event_type: eventType,
-                recorded_at: recordedAt,
-            }]);
-
-            const result = results?.[0];
-
-            if (result?.status === "synced" || result?.status === "duplicate") {
-                showSuccessScreen(employee, { event_id: result.event_id, recorded_at: recordedAt }, eventType);
+            if (ownResult && ownResult.status !== "synced" && ownResult.status !== "duplicate") {
+                // El servidor ya respondió que esta marcación puntual es inválida (ej. secuencia
+                // rota) — no tiene sentido dejarla "pendiente", se le informa directo al empleado.
+                showError(ownResult.message || "La marcación fue rechazada por el servidor.");
             } else {
-                showError(result?.message || "No se pudo registrar la marcación.");
+                // Sincronizada (ownResult existe y es synced/duplicate) o todavía en cola porque la
+                // red falló a mitad de camino (ownResult ausente) — en ambos casos ya está a salvo.
+                showSuccessScreen(employee, { recorded_at: recordedAt }, eventType, { queued: !ownResult });
             }
         } catch (error) {
-            console.error("Error al registrar marcación:", error);
-            showError(error instanceof TerminalAuthError ? error.message : "Error de conexión al registrar la marcación.");
+            console.error("Error al sincronizar la cola:", error);
+            // La marcación ya está encolada de forma segura — no se pierde aunque esto falle.
+            showSuccessScreen(employee, { recorded_at: recordedAt }, eventType, { queued: true });
         }
+
+        await refreshIdleSyncStatus();
     }
 
     // ============================================================================
@@ -844,7 +857,15 @@ document.addEventListener("DOMContentLoaded", () => {
     // ============================================================================
     // PANTALLAS DE RESULTADO
     // ============================================================================
-    function showSuccessScreen(employee, markData, eventType) {
+    /**
+     * @param {object} employee
+     * @param {{recorded_at?: string}} markData
+     * @param {string} eventType
+     * @param {{queued?: boolean}} [options] - queued=true: la marcación se guardó localmente
+     *        pero todavía no se confirmó con el servidor (sin red en el momento) — se avisa
+     *        sin asustar al empleado, ya que la marcación NO se perdió.
+     */
+    function showSuccessScreen(employee, markData, eventType, { queued = false } = {}) {
         const fullName = `${employee.first_name || ""} ${employee.last_name || ""}`.trim();
         if (successEmployeePhoto) {
             successEmployeePhoto.src = employee.photo_url || "";
@@ -858,6 +879,10 @@ document.addEventListener("DOMContentLoaded", () => {
         successTime.textContent = now.toLocaleTimeString("es-BO", {
             hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: false,
         });
+
+        if (successQueuedNotice) {
+            successQueuedNotice.style.display = queued ? "" : "none";
+        }
 
         playBeep("success");
         showScreen("success");
@@ -1036,6 +1061,23 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     /**
+     * Refleja en la pantalla idle el estado de la cola de eventos offline —
+     * se llama después de cada intento de sincronización (registerMark, sync
+     * en segundo plano, botón manual) para que el texto visible siempre
+     * refleje la cola real en IndexedDB, no solo el último resultado puntual.
+     */
+    async function refreshIdleSyncStatus() {
+        const [pending, conflicts] = await Promise.all([countPendingEvents(), countConflictEvents()]);
+        if (conflicts > 0) {
+            updateIdleSyncStatus(`${conflicts} marcación(es) requieren revisión`);
+        } else if (pending > 0) {
+            updateIdleSyncStatus(`${pending} marcación(es) pendiente(s) de sincronizar`);
+        } else {
+            updateIdleSyncStatus(navigator.onLine ? "Sincronizado" : "Sin conexión — usando datos locales");
+        }
+    }
+
+    /**
      * Migra el token de configuración (si venía de localStorage, ver
      * terminal-setup.blade.php) y hace la primera sincronización antes de
      * arrancar el reposo. Si el terminal no está provisionado, no bloquea el
@@ -1055,8 +1097,9 @@ document.addEventListener("DOMContentLoaded", () => {
         try {
             updateIdleSyncStatus("Sincronizando...");
             await heartbeat();
-            const result = await syncEmployees();
-            updateIdleSyncStatus(`Sincronizado — ${result.employees ? "actualizado" : "sin cambios"}`);
+            await syncEmployees();
+            await flushQueue();
+            await refreshIdleSyncStatus();
         } catch (error) {
             console.warn("Sincronización inicial falló (se reintentará en segundo plano):", error.message);
             updateIdleSyncStatus(navigator.onLine ? "Error al sincronizar" : "Sin conexión — usando datos locales");
@@ -1065,7 +1108,10 @@ document.addEventListener("DOMContentLoaded", () => {
         startBackgroundSync();
     }
 
-    /** Heartbeat + sync de empleados periódicos mientras haya conexión, más un intento al recuperarla. */
+    /**
+     * Heartbeat + sync de empleados + vaciado de la cola de eventos,
+     * periódicos mientras haya conexión, más un intento al recuperarla.
+     */
     function startBackgroundSync() {
         if (terminalState.backgroundSyncStarted) return;
         terminalState.backgroundSyncStarted = true;
@@ -1076,17 +1122,23 @@ document.addEventListener("DOMContentLoaded", () => {
         };
         const runEmployeeSync = () => {
             if (!navigator.onLine) return;
-            syncEmployees()
-                .then((result) => updateIdleSyncStatus(`Sincronizado — ${result.employees} empleados`))
-                .catch((error) => console.warn("Sync de empleados en segundo plano falló:", error.message));
+            syncEmployees().catch((error) => console.warn("Sync de empleados en segundo plano falló:", error.message));
+        };
+        const runQueueFlush = () => {
+            if (!navigator.onLine) return;
+            flushQueue()
+                .then(() => refreshIdleSyncStatus())
+                .catch((error) => console.warn("Sincronización de cola en segundo plano falló:", error.message));
         };
 
         setInterval(runHeartbeat, 90 * 1000);
         setInterval(runEmployeeSync, 5 * 60 * 1000);
+        setInterval(runQueueFlush, 30 * 1000);
 
         window.addEventListener("online", () => {
             runHeartbeat();
             runEmployeeSync();
+            runQueueFlush();
         });
     }
 
@@ -1098,8 +1150,9 @@ document.addEventListener("DOMContentLoaded", () => {
             updateIdleSyncStatus("Sincronizando...");
             try {
                 await heartbeat();
-                const result = await syncEmployees();
-                updateIdleSyncStatus(`Sincronizado — ${result.employees} empleados`);
+                await syncEmployees();
+                await flushQueue();
+                await refreshIdleSyncStatus();
             } catch (error) {
                 updateIdleSyncStatus(error instanceof TerminalAuthError ? "Terminal sin configurar" : "Error al sincronizar");
             } finally {

--- a/resources/views/components/attendance/terminal-success.blade.php
+++ b/resources/views/components/attendance/terminal-success.blade.php
@@ -30,6 +30,10 @@
                 </div>
             </div>
 
+            <p class="success-queued-notice" id="successQueuedNotice" style="display:none" role="status">
+                Guardado en el dispositivo — se sincronizará cuando haya conexión.
+            </p>
+
             <div class="countdown-bar" aria-hidden="true">
                 <div class="countdown-fill" id="countdownFill"></div>
             </div>

--- a/tests/Feature/AttendanceEventSyncServiceTest.php
+++ b/tests/Feature/AttendanceEventSyncServiceTest.php
@@ -1,0 +1,155 @@
+<?php
+
+use App\Models\AttendanceEvent;
+use App\Models\AttendanceMarkFailure;
+use App\Models\Branch;
+use App\Models\Company;
+use App\Models\Contract;
+use App\Models\Department;
+use App\Models\Employee;
+use App\Models\Position;
+use App\Models\Terminal;
+use App\Services\AttendanceEventSyncService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+
+uses(RefreshDatabase::class);
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeSyncEmployee(): Employee
+{
+    static $ci = 8000000;
+    $n = $ci++;
+
+    $company = Company::create(['name' => "Empresa Sync {$n}", 'ruc' => "{$n}-1", 'employer_number' => $n]);
+    $branch = Branch::create(['name' => "Sucursal Sync {$n}", 'company_id' => $company->id]);
+    $department = Department::create(['name' => "Depto Sync {$n}", 'company_id' => $company->id]);
+    $position = Position::create(['name' => "Cargo Sync {$n}", 'department_id' => $department->id]);
+
+    $employee = Employee::create([
+        'first_name' => 'Sync',
+        'last_name' => 'Test',
+        'ci' => (string) $n,
+        'email' => "sync{$n}@test.com",
+        'branch_id' => $branch->id,
+        'status' => 'active',
+    ]);
+
+    Contract::create([
+        'employee_id' => $employee->id,
+        'type' => 'indefinido',
+        'start_date' => now()->subYear(),
+        'salary_type' => 'mensual',
+        'salary' => 2_550_000,
+        'position_id' => $position->id,
+        'department_id' => $department->id,
+        'status' => 'active',
+    ]);
+
+    return $employee->fresh();
+}
+
+function makeSyncTerminal(Employee $employee): Terminal
+{
+    return Terminal::create([
+        'name' => 'Kiosko Test',
+        'branch_id' => $employee->branch_id,
+    ]);
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+it('sincroniza un evento nuevo y lo marca con origen terminal', function () {
+    $employee = makeSyncEmployee();
+    $terminal = makeSyncTerminal($employee);
+    $clientEventId = (string) Str::uuid();
+
+    $results = app(AttendanceEventSyncService::class)->syncBatch($terminal, [[
+        'client_event_id' => $clientEventId,
+        'employee_id' => $employee->id,
+        'event_type' => 'check_in',
+        'recorded_at' => '2026-08-19 08:00:00',
+    ]]);
+
+    expect($results[0]['status'])->toBe('synced');
+
+    $event = AttendanceEvent::where('client_event_id', $clientEventId)->first();
+    expect($event)->not->toBeNull()
+        ->and($event->source)->toBe('terminal')
+        ->and($event->synced_at)->not->toBeNull()
+        ->and($event->terminal_id)->toBe($terminal->id);
+});
+
+it('es idempotente — reenviar el mismo client_event_id no duplica el evento', function () {
+    $employee = makeSyncEmployee();
+    $terminal = makeSyncTerminal($employee);
+    $clientEventId = (string) Str::uuid();
+    $payload = [[
+        'client_event_id' => $clientEventId,
+        'employee_id' => $employee->id,
+        'event_type' => 'check_in',
+        'recorded_at' => '2026-08-19 08:00:00',
+    ]];
+
+    $service = app(AttendanceEventSyncService::class);
+    $service->syncBatch($terminal, $payload);
+    $results = $service->syncBatch($terminal, $payload);
+
+    expect($results[0]['status'])->toBe('duplicate')
+        ->and(AttendanceEvent::where('client_event_id', $clientEventId)->count())->toBe(1);
+});
+
+it('rechaza como conflict un evento cuya secuencia ya no es válida en el servidor y lo registra para revisión', function () {
+    $employee = makeSyncEmployee();
+    $terminal = makeSyncTerminal($employee);
+    $service = app(AttendanceEventSyncService::class);
+
+    // El check_out ya llegó al servidor (ej. desde otro origen mientras el kiosko estaba offline).
+    $service->syncBatch($terminal, [[
+        'client_event_id' => (string) Str::uuid(),
+        'employee_id' => $employee->id,
+        'event_type' => 'check_out',
+        'recorded_at' => '2026-08-19 17:00:00',
+    ]]);
+
+    // El kiosko recién ahora sincroniza un break_start que había capturado offline, antes del check_out.
+    $conflictingClientEventId = (string) Str::uuid();
+    $results = $service->syncBatch($terminal, [[
+        'client_event_id' => $conflictingClientEventId,
+        'employee_id' => $employee->id,
+        'event_type' => 'break_start',
+        'recorded_at' => '2026-08-19 12:00:00',
+    ]]);
+
+    expect($results[0]['status'])->toBe('conflict')
+        ->and($results[0]['conflict_reason'])->toBe('invalid_sequence')
+        ->and(AttendanceEvent::where('client_event_id', $conflictingClientEventId)->exists())->toBeFalse();
+
+    $failure = AttendanceMarkFailure::where('failure_type', 'sync_conflict')->first();
+    expect($failure)->not->toBeNull()
+        ->and($failure->mode)->toBe('terminal')
+        ->and($failure->employee_id)->toBe($employee->id)
+        ->and($failure->branch_id)->toBe($terminal->branch_id);
+});
+
+it('rechaza un evento de un empleado inexistente o inactivo y lo registra para revisión', function () {
+    $employee = makeSyncEmployee();
+    $terminal = makeSyncTerminal($employee);
+    $clientEventId = (string) Str::uuid();
+
+    $results = app(AttendanceEventSyncService::class)->syncBatch($terminal, [[
+        'client_event_id' => $clientEventId,
+        'employee_id' => 999999,
+        'event_type' => 'check_in',
+        'recorded_at' => '2026-08-19 08:00:00',
+    ]]);
+
+    expect($results[0]['status'])->toBe('rejected')
+        ->and($results[0]['conflict_reason'])->toBe('employee_not_found');
+
+    $failure = AttendanceMarkFailure::where('failure_type', 'employee_not_found')
+        ->where('metadata->client_event_id', $clientEventId)
+        ->first();
+    expect($failure)->not->toBeNull();
+});


### PR DESCRIPTION
## Resumen

Cuarta fase de la marcación offline vía PWA del kiosko/terminal (ver Fases 1–3: PR #77, #78, #79). Hasta ahora el matching facial era 100% local (Fase 3), pero la marcación seguía requiriendo red de punta a punta. Esta fase agrega la cola de eventos offline: la marcación se guarda primero en IndexedDB y se sincroniza en segundo plano.

- `resources/js/attendances/terminal-offline/queue.js` (nuevo): `enqueueMark()` guarda la marcación de forma durable antes de cualquier intento de red; `flushQueue()` sincroniza el lote pendiente — sincronizados/duplicados se eliminan de la cola, rechazados/en conflicto se marcan `conflict` (no se reintentan, quedan para revisión); `resolveEmployeeStatus()` combina el último estado confirmado por el servidor con los eventos que el propio kiosko ya encoló hoy, para saber qué botones mostrar sin red.
- `terminal.js`: `registerMark()` encola siempre primero y muestra la pantalla de éxito igual aunque la sync falle o no haya red (con un aviso de "se sincronizará cuando haya conexión"), para no mostrarle un error al empleado por algo que ya se guardó. La pantalla de reposo ahora refleja cuántas marcaciones están pendientes/en conflicto.
- **Servidor**: `AttendanceEventSyncService` ahora registra un `AttendanceMarkFailure` (`failure_type: sync_conflict`, nuevo) cuando un evento sincronizado ya no es válido por secuencia — visibilidad en Filament para conflictos que antes solo quedaban en el IndexedDB del cliente.

## Test plan

- [x] `tests/Feature/AttendanceEventSyncServiceTest.php` (nuevo, Pest): sync exitoso, idempotencia (reenvío no duplica), conflicto de secuencia (`check_out` ya sincronizado + evento atrasado del kiosko → `conflict` + `AttendanceMarkFailure`), empleado inexistente/inactivo.
- [x] Paridad 1:1 verificada entre `allowedNextEventTypes()` (JS) y `AttendanceEvent::allowedNextEventTypes()` (PHP).
- [x] `queue.js` probado end-to-end en navegador real (Playwright + IndexedDB real, red simulada vía interceptación de `fetch`): encolar offline, flush sin red (queda pendiente), flush al reconectar (sincroniza y vacía), evento marcado `conflict` por el servidor (no se reintenta), resolución local de estado a partir de eventos pendientes.
- [x] `vendor/bin/pint --dirty` sin hallazgos pendientes.
- [x] `npm run build` sin errores.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH)_