### PR TITLE
Agregar heartbeat/staleness de terminales al panel de Filament (Fase 5)

### DIFF
--- a/app/Filament/Pages/ManageGeneralSettings.php
+++ b/app/Filament/Pages/ManageGeneralSettings.php
@@ -105,6 +105,20 @@ class ManageGeneralSettings extends SettingsPage
                             ->default(0.1)
                             ->helperText('Diferencia mínima entre el mejor y el segundo candidato para evitar confusiones entre rostros similares'),
                     ]),
+
+                Section::make('Terminales de Marcación')
+                    ->description('Configuración de conectividad para kioskos offline (marcación vía PWA)')
+                    ->icon('heroicon-o-wifi')
+                    ->schema([
+                        TextInput::make('terminal_stale_threshold_hours')
+                            ->label('Umbral de desconexión')
+                            ->numeric()
+                            ->minValue(1)
+                            ->maxValue(72)
+                            ->default(2)
+                            ->suffix('horas')
+                            ->helperText('Horas sin heartbeat exitoso antes de marcar un terminal como desconectado en el panel'),
+                    ]),
             ]);
     }
 }

--- a/app/Filament/Resources/TerminalResource.php
+++ b/app/Filament/Resources/TerminalResource.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources;
 
 use App\Filament\Resources\TerminalResource\Pages;
 use App\Models\Terminal;
+use App\Settings\GeneralSettings;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Components\Select;
@@ -24,6 +25,7 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
 use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Auth;
 use SimpleSoftwareIO\QrCode\Facades\QrCode;
 
@@ -205,18 +207,10 @@ class TerminalResource extends Resource
                                 ->placeholder('-'),
                         ]),
 
-                        InfoGrid::make(2)->schema([
-                            TextEntry::make('device_mac')
-                                ->label('Dirección MAC')
-                                ->copyable()
-                                ->placeholder('-'),
-
-                            TextEntry::make('last_seen_at')
-                                ->label('Última actividad')
-                                ->dateTime('d/m/Y H:i')
-                                ->placeholder('Sin actividad registrada')
-                                ->since(),
-                        ]),
+                        TextEntry::make('device_mac')
+                            ->label('Dirección MAC')
+                            ->copyable()
+                            ->placeholder('-'),
 
                         TextEntry::make('device_notes')
                             ->label('Notas')
@@ -224,6 +218,43 @@ class TerminalResource extends Resource
                             ->columnSpanFull(),
                     ])
                     ->visible(fn (Terminal $record) => $record->device_brand || $record->device_model || $record->device_serial || $record->device_mac || $record->device_notes),
+
+                InfoSection::make('Conectividad')
+                    ->description('Marcación offline vía PWA — heartbeat y sincronización con la API de terminales')
+                    ->icon('heroicon-o-wifi')
+                    ->schema([
+                        InfoGrid::make(4)->schema([
+                            TextEntry::make('connectivity_status')
+                                ->label('Estado')
+                                ->badge()
+                                ->formatStateUsing(fn (string $state) => Terminal::getConnectivityStatusLabels()[$state] ?? $state)
+                                ->color(fn (string $state) => Terminal::getConnectivityStatusColors()[$state] ?? 'gray'),
+
+                            TextEntry::make('last_heartbeat_at')
+                                ->label('Último heartbeat')
+                                ->dateTime('d/m/Y H:i')
+                                ->placeholder('Nunca')
+                                ->since(),
+
+                            TextEntry::make('last_employee_sync_at')
+                                ->label('Último sync de empleados')
+                                ->dateTime('d/m/Y H:i')
+                                ->placeholder('Nunca')
+                                ->since(),
+
+                            TextEntry::make('last_event_sync_at')
+                                ->label('Último sync de marcaciones')
+                                ->dateTime('d/m/Y H:i')
+                                ->placeholder('Nunca')
+                                ->since(),
+                        ]),
+
+                        TextEntry::make('last_seen_at')
+                            ->label('Última carga de página')
+                            ->dateTime('d/m/Y H:i')
+                            ->placeholder('Sin actividad registrada')
+                            ->since(),
+                    ]),
 
                 InfoSection::make('Instalación')
                     ->schema([
@@ -282,12 +313,26 @@ class TerminalResource extends Resource
                     ->color(fn (string $state) => Terminal::getStatusColors()[$state] ?? 'gray')
                     ->sortable(),
 
+                TextColumn::make('connectivity_status')
+                    ->label('Conectividad')
+                    ->badge()
+                    ->tooltip('Basado en el último heartbeat exitoso de sincronización offline')
+                    ->formatStateUsing(fn (string $state) => Terminal::getConnectivityStatusLabels()[$state] ?? $state)
+                    ->color(fn (string $state) => Terminal::getConnectivityStatusColors()[$state] ?? 'gray'),
+
+                TextColumn::make('last_heartbeat_at')
+                    ->label('Último heartbeat')
+                    ->since()
+                    ->placeholder('Nunca')
+                    ->sortable()
+                    ->toggleable(),
+
                 TextColumn::make('last_seen_at')
                     ->label('Última actividad')
                     ->since()
                     ->placeholder('Sin actividad')
                     ->sortable()
-                    ->toggleable(),
+                    ->toggleable(isToggledHiddenByDefault: true),
 
                 TextColumn::make('installed_at')
                     ->label('Instalada')
@@ -308,6 +353,25 @@ class TerminalResource extends Resource
                     ->label('Estado')
                     ->options(Terminal::getStatusOptions())
                     ->native(false),
+
+                SelectFilter::make('connectivity_status')
+                    ->label('Conectividad')
+                    ->options(Terminal::getConnectivityStatusOptions())
+                    ->native(false)
+                    ->query(function (Builder $query, array $data) {
+                        if (blank($data['value'] ?? null)) {
+                            return $query;
+                        }
+
+                        $threshold = now()->subHours(app(GeneralSettings::class)->terminal_stale_threshold_hours);
+
+                        return match ($data['value']) {
+                            'never_connected' => $query->whereNull('last_heartbeat_at'),
+                            'online' => $query->where('last_heartbeat_at', '>=', $threshold),
+                            'stale' => $query->whereNotNull('last_heartbeat_at')->where('last_heartbeat_at', '<', $threshold),
+                            default => $query,
+                        };
+                    }),
             ])
             ->actions([
                 ActionGroup::make([

--- a/app/Http/Controllers/Api/TerminalEmployeeSyncController.php
+++ b/app/Http/Controllers/Api/TerminalEmployeeSyncController.php
@@ -48,6 +48,8 @@ class TerminalEmployeeSyncController extends Controller
 
         $delta = $this->syncService->deltaSince($terminal, $since);
 
+        $terminal->update(['last_employee_sync_at' => now()]);
+
         return response()->json(array_merge(['ok' => true], $delta));
     }
 
@@ -56,9 +58,10 @@ class TerminalEmployeeSyncController extends Controller
      *
      * Estado de marcación del día en curso para un empleado ya identificado
      * localmente por el kiosko (matching client-side, ver terminal-offline/matcher.js).
-     * El kiosko todavía depende de esta consulta en línea para saber qué
-     * eventos son válidos a continuación — la resolución 100% offline de este
-     * estado es responsabilidad de una fase posterior (cola de eventos).
+     * El kiosko prefiere esta consulta en línea cuando hay red; si falla,
+     * cae a una resolución local equivalente combinando la última respuesta
+     * cacheada de este endpoint con sus propios eventos aún no confirmados
+     * (ver terminal-offline/queue.js, `resolveEmployeeStatus()`).
      */
     public function status(Request $request, Employee $employee): JsonResponse
     {

--- a/app/Http/Controllers/Api/TerminalEventSyncController.php
+++ b/app/Http/Controllers/Api/TerminalEventSyncController.php
@@ -48,6 +48,8 @@ class TerminalEventSyncController extends Controller
 
         $results = $this->syncService->syncBatch($terminal, $data['events']);
 
+        $terminal->update(['last_event_sync_at' => now()]);
+
         return response()->json([
             'ok' => true,
             'results' => $results,

--- a/app/Http/Controllers/Api/TerminalHeartbeatController.php
+++ b/app/Http/Controllers/Api/TerminalHeartbeatController.php
@@ -10,14 +10,16 @@ use Illuminate\Http\Request;
 
 /**
  * Heartbeat del terminal — se llama periódicamente mientras hay conexión
- * (y desde el botón "Forzar sincronización") para mantener `last_seen_at`
- * vivo y entregar la configuración vigente de reconocimiento facial, así el
- * kiosko no depende de un sync completo de empleados para tener el umbral
- * actualizado. Autenticado vía Sanctum (ability `terminal:sync`).
+ * (y desde el botón "Forzar sincronización") para mantener `last_seen_at`/
+ * `last_heartbeat_at` vivos y entregar la configuración vigente de
+ * reconocimiento facial, así el kiosko no depende de un sync completo de
+ * empleados para tener el umbral actualizado. Autenticado vía Sanctum
+ * (ability `terminal:sync`).
  *
- * Nota: en esta fase solo actualiza `last_seen_at` (ya existente). Las
- * columnas dedicadas de heartbeat/staleness (`last_heartbeat_at`, etc.) y su
- * UI en Filament se agregan en una fase posterior del rollout offline.
+ * `last_heartbeat_at` (a diferencia de `last_seen_at`, que también se
+ * actualiza con cada carga de página vía sesión) solo se actualiza acá —
+ * es la señal que usa `Terminal::connectivity_status` para el badge de
+ * conectividad en Filament (ver TerminalResource).
  */
 class TerminalHeartbeatController extends Controller
 {
@@ -26,7 +28,7 @@ class TerminalHeartbeatController extends Controller
         /** @var Terminal $terminal */
         $terminal = $request->user();
 
-        $terminal->update(['last_seen_at' => now()]);
+        $terminal->update(['last_seen_at' => now(), 'last_heartbeat_at' => now()]);
 
         return response()->json([
             'ok' => true,

--- a/app/Models/Terminal.php
+++ b/app/Models/Terminal.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Settings\GeneralSettings;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -36,6 +37,9 @@ class Terminal extends Model
         'installed_at',
         'installed_by_id',
         'last_seen_at',
+        'last_heartbeat_at',
+        'last_employee_sync_at',
+        'last_event_sync_at',
         'setup_token',
         'setup_token_expires_at',
     ];
@@ -47,6 +51,9 @@ class Terminal extends Model
     protected $casts = [
         'installed_at' => 'date',
         'last_seen_at' => 'datetime',
+        'last_heartbeat_at' => 'datetime',
+        'last_employee_sync_at' => 'datetime',
+        'last_event_sync_at' => 'datetime',
         'setup_token_expires_at' => 'datetime',
     ];
 
@@ -129,6 +136,48 @@ class Terminal extends Model
         ];
     }
 
+    /**
+     * Opciones de estado de conectividad para filtros.
+     *
+     * @return array<string, string>
+     */
+    public static function getConnectivityStatusOptions(): array
+    {
+        return [
+            'online' => 'En línea',
+            'stale' => 'Desconectado',
+            'never_connected' => 'Nunca conectado',
+        ];
+    }
+
+    /**
+     * Labels cortos para badges de conectividad.
+     *
+     * @return array<string, string>
+     */
+    public static function getConnectivityStatusLabels(): array
+    {
+        return [
+            'online' => 'En línea',
+            'stale' => 'Desconectado',
+            'never_connected' => 'Nunca conectado',
+        ];
+    }
+
+    /**
+     * Colores semánticos para badges de conectividad.
+     *
+     * @return array<string, string>
+     */
+    public static function getConnectivityStatusColors(): array
+    {
+        return [
+            'online' => 'success',
+            'stale' => 'danger',
+            'never_connected' => 'gray',
+        ];
+    }
+
     // =========================================================================
     // VERIFICADORES DE ESTADO
     // =========================================================================
@@ -143,6 +192,28 @@ class Terminal extends Model
     public function isInactive(): bool
     {
         return $this->status === 'inactive';
+    }
+
+    /**
+     * Estado de conectividad calculado a partir de `last_heartbeat_at` (a
+     * diferencia de `last_seen_at`, que también se actualiza con cada carga
+     * de página vía sesión y por eso no distingue un kiosko que quedó abierto
+     * offline días de uno que realmente sigue sincronizando):
+     * - 'never_connected': nunca completó un heartbeat exitoso (sin
+     *   provisionar, o provisionado pero sin conexión desde entonces).
+     * - 'online': el último heartbeat exitoso está dentro del umbral
+     *   configurado (`GeneralSettings->terminal_stale_threshold_hours`).
+     * - 'stale': el último heartbeat exitoso superó el umbral.
+     */
+    public function getConnectivityStatusAttribute(): string
+    {
+        if (! $this->last_heartbeat_at instanceof Carbon) {
+            return 'never_connected';
+        }
+
+        $thresholdHours = app(GeneralSettings::class)->terminal_stale_threshold_hours;
+
+        return $this->last_heartbeat_at->lt(now()->subHours($thresholdHours)) ? 'stale' : 'online';
     }
 
     // =========================================================================

--- a/app/Models/Terminal.php
+++ b/app/Models/Terminal.php
@@ -3,6 +3,8 @@
 namespace App\Models;
 
 use App\Settings\GeneralSettings;
+use Illuminate\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -16,10 +18,17 @@ use Laravel\Sanctum\HasApiTokens;
  * Puede autenticarse contra la API de sincronización offline (ver routes/api.php)
  * mediante un token Sanctum con ability `terminal:sync`, emitido al reclamar un
  * enlace de configuración (setup_token) generado desde TerminalResource.
+ *
+ * Implementa `Authenticatable` (no solo `HasApiTokens`) porque el terminal es
+ * el "usuario" autenticado en las rutas de la API de sincronización — sin
+ * esto, `$request->user()` funciona en producción (el guard de Sanctum
+ * resuelve el usuario sin pasar por `Guard::setUser()`), pero el helper de
+ * test `Sanctum::actingAs()` sí llama `setUser()` directamente, que exige
+ * el contrato `Authenticatable` con tipado estricto.
  */
-class Terminal extends Model
+class Terminal extends Model implements AuthenticatableContract
 {
-    use HasApiTokens;
+    use Authenticatable, HasApiTokens;
 
     /** Ability Sanctum requerida para consumir la API de sincronización de terminales. */
     public const SYNC_ABILITY = 'terminal:sync';

--- a/app/Settings/GeneralSettings.php
+++ b/app/Settings/GeneralSettings.php
@@ -18,6 +18,8 @@ class GeneralSettings extends Settings
 
     public float $face_min_confidence_gap;
 
+    public int $terminal_stale_threshold_hours;
+
     public static function group(): string
     {
         return 'general';

--- a/database/migrations/2026_08_19_031253_add_heartbeat_fields_to_terminals_table.php
+++ b/database/migrations/2026_08_19_031253_add_heartbeat_fields_to_terminals_table.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Agrega columnas de heartbeat/staleness a terminals (Fase 5 del rollout
+ * offline vía PWA): a diferencia de `last_seen_at` (se actualiza también con
+ * cada carga de página, vía sesión), estos campos solo se actualizan cuando
+ * el terminal completa exitosamente cada tipo de sincronización con la API
+ * Sanctum — permiten distinguir "el kiosko cargó la página una vez" de "el
+ * kiosko está efectivamente sincronizando" en un dispositivo que puede
+ * quedar abierto días sin recargar.
+ *
+ * - last_heartbeat_at: último POST /api/v1/terminal/heartbeat exitoso.
+ * - last_employee_sync_at: último GET /api/v1/terminal/employees/sync exitoso.
+ * - last_event_sync_at: último POST /api/v1/terminal/events/sync exitoso.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('terminals', function (Blueprint $table) {
+            $table->timestamp('last_heartbeat_at')
+                ->nullable()
+                ->after('last_seen_at')
+                ->comment('Último heartbeat exitoso vía API Sanctum');
+
+            $table->timestamp('last_employee_sync_at')
+                ->nullable()
+                ->after('last_heartbeat_at')
+                ->comment('Último sync de empleados exitoso vía API Sanctum');
+
+            $table->timestamp('last_event_sync_at')
+                ->nullable()
+                ->after('last_employee_sync_at')
+                ->comment('Último envío de eventos de marcación exitoso vía API Sanctum');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('terminals', function (Blueprint $table) {
+            $table->dropColumn(['last_heartbeat_at', 'last_employee_sync_at', 'last_event_sync_at']);
+        });
+    }
+};

--- a/database/migrations/2026_08_19_031254_add_terminal_stale_threshold_to_general_settings.php
+++ b/database/migrations/2026_08_19_031254_add_terminal_stale_threshold_to_general_settings.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::table('settings')->insertOrIgnore([
+            'group' => 'general',
+            'name' => 'terminal_stale_threshold_hours',
+            'payload' => json_encode(2),
+            'locked' => false,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    public function down(): void
+    {
+        DB::table('settings')
+            ->where('group', 'general')
+            ->where('name', 'terminal_stale_threshold_hours')
+            ->delete();
+    }
+};

--- a/tests/Feature/TerminalConnectivityTest.php
+++ b/tests/Feature/TerminalConnectivityTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use App\Models\Branch;
+use App\Models\Company;
+use App\Models\Terminal;
+use App\Settings\GeneralSettings;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Laravel\Sanctum\Sanctum;
+
+uses(RefreshDatabase::class);
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeConnectivityTerminal(): Terminal
+{
+    static $n = 7000000;
+    $n++;
+
+    $company = Company::create(['name' => "Empresa Term {$n}", 'ruc' => "{$n}-1", 'employer_number' => $n]);
+    $branch = Branch::create(['name' => "Sucursal Term {$n}", 'company_id' => $company->id]);
+
+    return Terminal::create(['name' => 'Kiosko Test', 'branch_id' => $branch->id]);
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+it('nunca conectado cuando last_heartbeat_at es null', function () {
+    $terminal = makeConnectivityTerminal();
+
+    expect($terminal->connectivity_status)->toBe('never_connected');
+});
+
+it('en línea cuando el último heartbeat está dentro del umbral configurado', function () {
+    $settings = app(GeneralSettings::class);
+    $settings->terminal_stale_threshold_hours = 2;
+    $settings->save();
+
+    $terminal = makeConnectivityTerminal();
+    $terminal->update(['last_heartbeat_at' => now()->subHour()]);
+
+    expect($terminal->connectivity_status)->toBe('online');
+});
+
+it('desconectado cuando el último heartbeat superó el umbral configurado', function () {
+    $settings = app(GeneralSettings::class);
+    $settings->terminal_stale_threshold_hours = 2;
+    $settings->save();
+
+    $terminal = makeConnectivityTerminal();
+    $terminal->update(['last_heartbeat_at' => now()->subHours(3)]);
+
+    expect($terminal->connectivity_status)->toBe('stale');
+});
+
+it('el heartbeat de la API actualiza last_seen_at y last_heartbeat_at', function () {
+    $terminal = makeConnectivityTerminal();
+    Sanctum::actingAs($terminal, [Terminal::SYNC_ABILITY]);
+
+    $response = $this->postJson('/api/v1/terminal/heartbeat');
+
+    $response->assertOk()->assertJson(['ok' => true]);
+    $terminal->refresh();
+    expect($terminal->last_heartbeat_at)->not->toBeNull()
+        ->and($terminal->last_seen_at)->not->toBeNull();
+});
+
+it('el sync de empleados actualiza last_employee_sync_at', function () {
+    $terminal = makeConnectivityTerminal();
+    Sanctum::actingAs($terminal, [Terminal::SYNC_ABILITY]);
+
+    $response = $this->getJson('/api/v1/terminal/employees/sync');
+
+    $response->assertOk()->assertJson(['ok' => true]);
+    $terminal->refresh();
+    expect($terminal->last_employee_sync_at)->not->toBeNull();
+});
+
+it('el sync de eventos actualiza last_event_sync_at', function () {
+    $terminal = makeConnectivityTerminal();
+    Sanctum::actingAs($terminal, [Terminal::SYNC_ABILITY]);
+
+    $response = $this->postJson('/api/v1/terminal/events/sync', [
+        'events' => [[
+            'client_event_id' => (string) Str::uuid(),
+            'employee_id' => 999999,
+            'event_type' => 'check_in',
+            'recorded_at' => now()->toDateTimeString(),
+        ]],
+    ]);
+
+    $response->assertOk()->assertJson(['ok' => true]);
+    $terminal->refresh();
+    expect($terminal->last_event_sync_at)->not->toBeNull();
+});


### PR DESCRIPTION
## Resumen

Quinta fase de la marcación offline vía PWA del kiosko/terminal (ver Fases 1–4: PR #77, #78, #79, #80). Un kiosko offline puede quedar abierto días sin recargar la página (el Service Worker de la Fase 2 lo permite), así que `last_seen_at` (solo se actualiza al cargar `/terminal/{code}`) ya no es suficiente para saber si un terminal realmente sigue sincronizando. Esta fase agrega visibilidad de conectividad en Filament.

- **Migración** `terminals`: nuevos `last_heartbeat_at`, `last_employee_sync_at`, `last_event_sync_at` — cada uno estampado por su endpoint correspondiente de la API (`TerminalHeartbeatController`, `TerminalEmployeeSyncController`, `TerminalEventSyncController`) solo cuando la sincronización se completa con éxito.
- **Nuevo setting** `GeneralSettings->terminal_stale_threshold_hours` (default 2h, configurable desde Configuración General).
- **`Terminal::connectivity_status`** (nuevo accessor): `never_connected` / `online` / `stale`, según el último heartbeat exitoso vs. el umbral configurado.
- **`TerminalResource`**: badge de conectividad + columna de último heartbeat en la tabla, filtro por conectividad, y una nueva sección "Conectividad" en el detalle del terminal con los 4 timestamps relevantes.

## Test plan

- [x] `tests/Feature/TerminalConnectivityTest.php` (nuevo, Pest): los 3 estados de `connectivity_status` según el umbral configurado, y que los 3 endpoints de la API estampan su timestamp correspondiente (HTTP real autenticado con Sanctum).
- [x] Verificado además con un servidor real (`php artisan serve` + curl con un Bearer token real emitido por `claimSanctumToken()`) contra los 3 endpoints.
- [x] Las dos migraciones nuevas se corrieron (`up()` y `down()`, incluyendo rollback) contra una BD de scratch para confirmar que agregan/eliminan las columnas y el setting correctamente.
- [x] `vendor/bin/pint --dirty` sin hallazgos. `npm run build` sin cambios de frontend en esta fase (fase server/Filament only).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH)_