### PR TITLE
Agregar hardening y runbook al rollout offline del kiosko (Fase 6)

### DIFF
--- a/app/Filament/Resources/TerminalResource.php
+++ b/app/Filament/Resources/TerminalResource.php
@@ -249,6 +249,23 @@ class TerminalResource extends Resource
                                 ->since(),
                         ]),
 
+                        InfoGrid::make(3)->schema([
+                            TextEntry::make('sync_queue_status')
+                                ->label('Cola de sincronización')
+                                ->badge()
+                                ->tooltip('Reportado por el kiosko en cada heartbeat')
+                                ->formatStateUsing(fn (string $state) => Terminal::getSyncQueueStatusLabels()[$state] ?? $state)
+                                ->color(fn (string $state) => Terminal::getSyncQueueStatusColors()[$state] ?? 'gray'),
+
+                            TextEntry::make('last_pending_events_count')
+                                ->label('Marcaciones pendientes')
+                                ->placeholder('Sin datos'),
+
+                            TextEntry::make('last_conflict_events_count')
+                                ->label('Marcaciones en conflicto')
+                                ->placeholder('Sin datos'),
+                        ]),
+
                         TextEntry::make('last_seen_at')
                             ->label('Última carga de página')
                             ->dateTime('d/m/Y H:i')
@@ -320,6 +337,13 @@ class TerminalResource extends Resource
                     ->formatStateUsing(fn (string $state) => Terminal::getConnectivityStatusLabels()[$state] ?? $state)
                     ->color(fn (string $state) => Terminal::getConnectivityStatusColors()[$state] ?? 'gray'),
 
+                TextColumn::make('sync_queue_status')
+                    ->label('Cola de sync')
+                    ->badge()
+                    ->tooltip('Marcaciones pendientes o en conflicto reportadas por el kiosko en su último heartbeat')
+                    ->formatStateUsing(fn (string $state) => Terminal::getSyncQueueStatusLabels()[$state] ?? $state)
+                    ->color(fn (string $state) => Terminal::getSyncQueueStatusColors()[$state] ?? 'gray'),
+
                 TextColumn::make('last_heartbeat_at')
                     ->label('Último heartbeat')
                     ->since()
@@ -369,6 +393,25 @@ class TerminalResource extends Resource
                             'never_connected' => $query->whereNull('last_heartbeat_at'),
                             'online' => $query->where('last_heartbeat_at', '>=', $threshold),
                             'stale' => $query->whereNotNull('last_heartbeat_at')->where('last_heartbeat_at', '<', $threshold),
+                            default => $query,
+                        };
+                    }),
+
+                SelectFilter::make('sync_queue_status')
+                    ->label('Cola de sync')
+                    ->options(Terminal::getSyncQueueStatusOptions())
+                    ->native(false)
+                    ->query(function (Builder $query, array $data) {
+                        if (blank($data['value'] ?? null)) {
+                            return $query;
+                        }
+
+                        return match ($data['value']) {
+                            'conflict' => $query->where('last_conflict_events_count', '>', 0),
+                            'pending' => $query->where('last_pending_events_count', '>', 0)
+                                ->where(fn ($q) => $q->whereNull('last_conflict_events_count')->orWhere('last_conflict_events_count', 0)),
+                            'ok' => $query->where(fn ($q) => $q->whereNull('last_pending_events_count')->orWhere('last_pending_events_count', 0))
+                                ->where(fn ($q) => $q->whereNull('last_conflict_events_count')->orWhere('last_conflict_events_count', 0)),
                             default => $query,
                         };
                     }),

--- a/app/Http/Controllers/Api/TerminalHeartbeatController.php
+++ b/app/Http/Controllers/Api/TerminalHeartbeatController.php
@@ -20,15 +20,32 @@ use Illuminate\Http\Request;
  * actualiza con cada carga de página vía sesión) solo se actualiza acá —
  * es la señal que usa `Terminal::connectivity_status` para el badge de
  * conectividad en Filament (ver TerminalResource).
+ *
+ * También recibe opcionalmente `pending_events`/`conflict_events` — el
+ * tamaño de la cola offline del kiosko (`outbound_events` en IndexedDB, ver
+ * terminal-offline/queue.js) al momento del heartbeat. Sin esto, un
+ * terminal con la cola atascada (ej. eventos en conflicto que requieren
+ * revisión) se ve "en línea" igual que uno sano, porque el heartbeat en sí
+ * sigue llegando — ver `Terminal::sync_queue_status` para el badge en Filament.
  */
 class TerminalHeartbeatController extends Controller
 {
     public function store(Request $request, GeneralSettings $settings): JsonResponse
     {
+        $data = $request->validate([
+            'pending_events' => ['nullable', 'integer', 'min:0'],
+            'conflict_events' => ['nullable', 'integer', 'min:0'],
+        ]);
+
         /** @var Terminal $terminal */
         $terminal = $request->user();
 
-        $terminal->update(['last_seen_at' => now(), 'last_heartbeat_at' => now()]);
+        $terminal->update([
+            'last_seen_at' => now(),
+            'last_heartbeat_at' => now(),
+            'last_pending_events_count' => $data['pending_events'] ?? null,
+            'last_conflict_events_count' => $data['conflict_events'] ?? null,
+        ]);
 
         return response()->json([
             'ok' => true,

--- a/app/Models/Terminal.php
+++ b/app/Models/Terminal.php
@@ -49,6 +49,8 @@ class Terminal extends Model implements AuthenticatableContract
         'last_heartbeat_at',
         'last_employee_sync_at',
         'last_event_sync_at',
+        'last_pending_events_count',
+        'last_conflict_events_count',
         'setup_token',
         'setup_token_expires_at',
     ];
@@ -63,6 +65,8 @@ class Terminal extends Model implements AuthenticatableContract
         'last_heartbeat_at' => 'datetime',
         'last_employee_sync_at' => 'datetime',
         'last_event_sync_at' => 'datetime',
+        'last_pending_events_count' => 'integer',
+        'last_conflict_events_count' => 'integer',
         'setup_token_expires_at' => 'datetime',
     ];
 
@@ -187,6 +191,48 @@ class Terminal extends Model implements AuthenticatableContract
         ];
     }
 
+    /**
+     * Opciones de estado de cola de sincronización para filtros.
+     *
+     * @return array<string, string>
+     */
+    public static function getSyncQueueStatusOptions(): array
+    {
+        return [
+            'ok' => 'Sin pendientes',
+            'pending' => 'Con pendientes',
+            'conflict' => 'Con conflictos',
+        ];
+    }
+
+    /**
+     * Labels cortos para badges de cola de sincronización.
+     *
+     * @return array<string, string>
+     */
+    public static function getSyncQueueStatusLabels(): array
+    {
+        return [
+            'ok' => 'Sin pendientes',
+            'pending' => 'Con pendientes',
+            'conflict' => 'Con conflictos',
+        ];
+    }
+
+    /**
+     * Colores semánticos para badges de cola de sincronización.
+     *
+     * @return array<string, string>
+     */
+    public static function getSyncQueueStatusColors(): array
+    {
+        return [
+            'ok' => 'gray',
+            'pending' => 'warning',
+            'conflict' => 'danger',
+        ];
+    }
+
     // =========================================================================
     // VERIFICADORES DE ESTADO
     // =========================================================================
@@ -223,6 +269,31 @@ class Terminal extends Model implements AuthenticatableContract
         $thresholdHours = app(GeneralSettings::class)->terminal_stale_threshold_hours;
 
         return $this->last_heartbeat_at->lt(now()->subHours($thresholdHours)) ? 'stale' : 'online';
+    }
+
+    /**
+     * Estado de la cola de sincronización offline del kiosko, a partir de lo
+     * reportado en el último heartbeat exitoso (`last_pending_events_count`/
+     * `last_conflict_events_count`) — complementa `connectivity_status`: un
+     * terminal puede verse "en línea" (el heartbeat llega con normalidad) y
+     * aun así tener la cola de marcaciones atascada, típicamente por eventos
+     * en conflicto que requieren revisión manual (ver `AttendanceMarkFailure`,
+     * `failure_type: sync_conflict`).
+     * - 'conflict': hay al menos un evento en conflicto.
+     * - 'pending': sin conflictos, pero hay eventos pendientes de sincronizar.
+     * - 'ok': sin pendientes ni conflictos (o el terminal nunca reportó el dato).
+     */
+    public function getSyncQueueStatusAttribute(): string
+    {
+        if (($this->last_conflict_events_count ?? 0) > 0) {
+            return 'conflict';
+        }
+
+        if (($this->last_pending_events_count ?? 0) > 0) {
+            return 'pending';
+        }
+
+        return 'ok';
     }
 
     // =========================================================================

--- a/database/migrations/2026_08_19_085124_add_sync_queue_counts_to_terminals_table.php
+++ b/database/migrations/2026_08_19_085124_add_sync_queue_counts_to_terminals_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Agrega los contadores de cola offline que el kiosko reporta en cada
+ * heartbeat (Fase 6 — hardening): sin esto, el badge de conectividad
+ * (Fase 5) no distingue un terminal con red intermitente y una cola de
+ * marcaciones atascada de uno realmente sano — ambos se ven "en línea"
+ * porque el heartbeat en sí llega, aunque la cola de `outbound_events` del
+ * lado del cliente (ver terminal-offline/queue.js) no se esté vaciando.
+ *
+ * Nullable porque un terminal que nunca hizo heartbeat (o uno con una
+ * versión vieja del bundle, antes de esta fase) no reporta el dato — se
+ * distingue de "0 pendientes" para no dar una falsa sensación de salud.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('terminals', function (Blueprint $table) {
+            $table->unsignedInteger('last_pending_events_count')
+                ->nullable()
+                ->after('last_event_sync_at')
+                ->comment('Eventos pendientes de sincronizar reportados en el último heartbeat');
+
+            $table->unsignedInteger('last_conflict_events_count')
+                ->nullable()
+                ->after('last_pending_events_count')
+                ->comment('Eventos en conflicto (requieren revisión manual) reportados en el último heartbeat');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('terminals', function (Blueprint $table) {
+            $table->dropColumn(['last_pending_events_count', 'last_conflict_events_count']);
+        });
+    }
+};

--- a/docs/runbook-terminal-revocacion-reprovision.md
+++ b/docs/runbook-terminal-revocacion-reprovision.md
@@ -1,0 +1,70 @@
+# Runbook: Revocación y reprovisión de terminales offline
+
+Guía operativa para el equipo de soporte/administración de **Nominapp** ante la pérdida, robo o reemplazo de un dispositivo kiosko de marcación de asistencia (terminal offline vía PWA).
+
+---
+
+## Cuándo aplica
+
+- El dispositivo físico del kiosko se perdió o fue robado.
+- Se reemplaza el hardware de un kiosko existente (tablet/PC nueva en la misma sucursal).
+- Se sospecha que el token de sincronización de un terminal fue comprometido (ej. acceso no autorizado al dispositivo).
+- Un terminal se va a dar de baja definitivamente (la sucursal cierra, o se reemplaza el proceso de marcación).
+
+En todos estos casos, el token Sanctum del terminal (`ability: terminal:sync`) sigue siendo válido hasta que se revoque explícitamente — **no expira solo**. Actuar rápido ante una pérdida es importante: quien tenga el dispositivo físico puede seguir marcando asistencias (o consultando la caché de empleados sincronizada) hasta que el token se revoque.
+
+## Qué NO cubre este runbook
+
+- **Borrado remoto del dispositivo perdido**: no existe hoy un mecanismo para borrar la caché de IndexedDB (empleados, descriptores faciales) de un dispositivo físico que ya no está bajo control. Revocar el token evita que ese dispositivo pueda seguir *sincronizando* con el servidor, pero los datos que ya tenía cacheados localmente permanecen en el dispositivo. Ver [Riesgos aceptados](#riesgos-aceptados) más abajo.
+- Incidentes de seguridad más amplios (compromiso del servidor, credenciales de admin filtradas) — este runbook es específico para un terminal individual.
+
+---
+
+## Paso 1 — Revocar el token del terminal comprometido/perdido
+
+1. Ir a **Filament → Asistencias → Terminales**.
+2. Ubicar el terminal afectado (por nombre o sucursal).
+3. Abrir el menú de acciones de la fila (`⋮`) y seleccionar **"Revocar token"**.
+4. Confirmar en el modal. Esto invalida inmediatamente el token Sanctum — el próximo intento de sincronización desde ese dispositivo recibirá `401`/`403` y el kiosko mostrará "Terminal sin configurar" (o el mensaje equivalente de re-provisión).
+
+**No hace falta desactivar el terminal** (`status: inactive`) al revocar el token — son conceptos independientes: `status` controla si el terminal puede usarse para marcar (vía `/terminal/{code}`), mientras que el token controla el acceso a la API de sincronización offline. Si el dispositivo físico se perdió y no se va a recuperar, desactivar el terminal además de revocar el token evita que alguien reactive el acceso reutilizando la URL pública.
+
+## Paso 2 — Confirmar que el terminal quedó sin acceso
+
+En la tabla de Terminales, la columna **Conectividad** del terminal revocado eventualmente pasará a "Desconectado" y luego (tras el umbral configurado en `Configuración General → Terminales de Marcación`) no se actualizará más — es esperado, ya no puede completar heartbeats. No hace falta esperar a que esto pase para continuar con la reprovisión.
+
+## Paso 3 — Reprovisionar (dispositivo nuevo o el mismo ya recuperado)
+
+1. En la misma fila del terminal, abrir **"Generar enlace de configuración"**.
+2. Se genera un enlace/QR de un solo uso, válido por 30 minutos. Este paso también invalida cualquier enlace de configuración anterior sin usar.
+3. Con el dispositivo físico **conectado a internet**, abrir el enlace (o escanear el QR) una única vez. Esto reclama un token Sanctum nuevo y lo guarda en el propio dispositivo (IndexedDB) — el token nunca aparece en la URL ni se muestra en pantalla más que la primera vez.
+4. Una vez completada la configuración, navegar a `/terminal/{code}` normalmente y dejar el dispositivo funcionando con conexión al menos hasta que complete el primer heartbeat y el primer sync de empleados.
+
+## Paso 4 — Verificar que la reprovisión funcionó
+
+En **Filament → Asistencias → Terminales → (ver el terminal)**, sección **Conectividad**:
+
+- **Estado**: debe pasar a "En línea" dentro de los primeros segundos/minutos (heartbeat cada 90s mientras hay red).
+- **Último sync de empleados**: debe tener una fecha reciente — confirma que la caché de empleados/descriptores se está descargando de nuevo en el dispositivo nuevo.
+- **Cola de sincronización**: debe estar en "Sin pendientes" — si aparece "Con pendientes" o "Con conflictos" persistentemente, revisar `AttendanceMarkFailureResource` (filtrado por el terminal/sucursal) antes de dar el proceso por cerrado.
+
+Si el terminal no pasa a "En línea" en un tiempo razonable, verificar:
+- Que el dispositivo tenga conexión real a internet (no solo a una red local sin salida).
+- Que la URL usada sea la correcta (`/terminal/{code}` con el código del terminal, no uno viejo).
+- Los logs del servidor (`storage/logs/laravel-*.log`) por errores 401/403 repetidos, que indicarían que el token no se guardó correctamente en el dispositivo.
+
+---
+
+## Riesgos aceptados
+
+- **Biometría sin cifrar en el dispositivo perdido**: la caché de `employees_cache` (IndexedDB) incluye los descriptores faciales de los empleados de la sucursal, en texto plano — mismo nivel de exposición que el caché server-side (`Cache::remember('employees_face_descriptors', ...)`). Revocar el token detiene la sincronización futura, pero no borra lo que ya estaba cacheado en el dispositivo perdido. Si el dispositivo se recupera físicamente, no hace falta ninguna acción adicional — el token revocado ya impide que vuelva a sincronizar sin pasar por reprovisión.
+- **Ventana entre la pérdida y la revocación**: mientras el token no se revoca, el dispositivo puede seguir marcando asistencias y sincronizando eventos con normalidad. No hay alerta automática de "terminal reportado como perdido" — depende de que el equipo de soporte actúe apenas se entera del incidente.
+
+## Checklist rápido
+
+- [ ] Revocar el token del terminal afectado (Filament → Terminales → Revocar token)
+- [ ] Si el dispositivo no se va a recuperar: marcar el terminal como `Inactiva`
+- [ ] Generar un nuevo enlace de configuración
+- [ ] Provisionar el dispositivo nuevo (o el mismo, ya recuperado) con el enlace, online
+- [ ] Confirmar "En línea" + sync de empleados reciente + "Sin pendientes" en la sección Conectividad
+- [ ] Si el terminal fue reemplazado por hardware nuevo: actualizar los datos del dispositivo físico (marca/modelo/serie) en la ficha del terminal

--- a/resources/js/attendances/terminal-offline/queue.js
+++ b/resources/js/attendances/terminal-offline/queue.js
@@ -13,6 +13,7 @@
  */
 
 import {
+    getMeta,
     queueEvent,
     getPendingEvents,
     getEventsForEmployeeOnDate,
@@ -52,6 +53,18 @@ export function allowedNextEventTypes(lastEventType) {
     }
 }
 
+/**
+ * Hora actual corregida con el offset de reloj del último heartbeat exitoso
+ * (`server_clock_offset_ms`, ver sync.js) — un kiosko sin NTP configurado
+ * puede tener el reloj local desviado, lo que arrastraría el error a cada
+ * marcación capturada offline. Sin heartbeat previo el offset es 0.
+ * @returns {Promise<Date>}
+ */
+async function correctedNow() {
+    const offsetMs = (await getMeta('server_clock_offset_ms')) || 0;
+    return new Date(Date.now() + offsetMs);
+}
+
 /** @returns {string} Fecha local del dispositivo en formato YYYY-MM-DD. */
 function localDateString(date = new Date()) {
     const year = date.getFullYear();
@@ -72,7 +85,7 @@ function localDateString(date = new Date()) {
  */
 export async function resolveEmployeeStatus(employeeId) {
     const cached = await getEmployeeStatusCache(employeeId);
-    const today = localDateString();
+    const today = localDateString(await correctedNow());
     const localEvents = (await getEventsForEmployeeOnDate(employeeId, today))
         .filter((event) => event.status === 'pending') // los en conflicto no cuentan como "ya registrados"
         .sort((a, b) => a.recorded_at.localeCompare(b.recorded_at));
@@ -113,13 +126,19 @@ export async function getEmployeeStatus(employeeId) {
  * Encola una marcación capturada localmente. Debe llamarse ANTES de intentar
  * sincronizar — así la marcación queda a salvo aunque el envío falle o la
  * pestaña se cierre a mitad de camino.
+ *
+ * `recorded_at` se corrige con el offset de reloj calculado en el último
+ * heartbeat exitoso (`server_clock_offset_ms`, ver sync.js) — un kiosko sin
+ * NTP configurado puede tener el reloj local desviado varios minutos, y esa
+ * desviación se arrastraría a cada marcación capturada mientras estuvo
+ * offline. Sin heartbeat previo el offset es 0 (no hay corrección posible).
  * @param {number} employeeId
  * @param {string} eventType
  * @returns {Promise<{client_event_id: string, recorded_at: string}>}
  */
 export async function enqueueMark(employeeId, eventType) {
     const clientEventId = crypto.randomUUID();
-    const recordedAt = new Date();
+    const recordedAt = await correctedNow();
 
     await queueEvent({
         client_event_id: clientEventId,
@@ -136,15 +155,29 @@ export async function enqueueMark(employeeId, eventType) {
 let flushInProgress = false;
 
 /**
- * Intenta sincronizar todos los eventos pendientes en un solo lote. Los
- * `synced`/`duplicate` se eliminan de la cola; los `conflict`/`rejected` se
- * marcan como tal (no se reintentan más) para revisión manual en Filament.
- * Si la red falla directamente (ni siquiera hay respuesta), todos quedan
- * `pending` para el próximo intento.
+ * Máximo de eventos por request de sincronización — debe coincidir con el
+ * límite del servidor (`TerminalEventSyncController`: `'events' => [...,
+ * 'max:200']`). Una sucursal con varios empleados y varias horas offline
+ * puede acumular más de 200 marcaciones en la cola; sin este chunking, un
+ * solo `submitEvents()` con todo de una vez se rechaza entero (422) y la
+ * cola queda atascada indefinidamente (confirmado con una prueba de carga
+ * de 250 eventos antes de este fix).
+ */
+const MAX_BATCH_SIZE = 200;
+
+/**
+ * Intenta sincronizar todos los eventos pendientes, en lotes de a lo sumo
+ * `MAX_BATCH_SIZE`. Los `synced`/`duplicate` se eliminan de la cola; los
+ * `conflict`/`rejected` se marcan como tal (no se reintentan más) para
+ * revisión manual en Filament. Si un lote falla por red (ni siquiera hay
+ * respuesta), ese lote y los siguientes quedan `pending` para el próximo
+ * intento — no tiene sentido seguir mandando lotes si el primero ya no
+ * pudo salir.
  *
  * Devuelve `results` (la respuesta cruda del servidor, una entrada por
- * `client_event_id`) para que el caller pueda saber qué pasó específicamente
- * con SU evento cuando encoló varios a la vez con otros ya pendientes.
+ * `client_event_id`, acumulada de todos los lotes que sí llegaron) para que
+ * el caller pueda saber qué pasó específicamente con SU evento cuando
+ * encoló varios a la vez con otros ya pendientes.
  * @returns {Promise<{synced: number, conflicts: number, stillPending: number, results: Array<object>}>}
  */
 export async function flushQueue() {
@@ -155,35 +188,42 @@ export async function flushQueue() {
         const pending = await getPendingEvents();
         if (pending.length === 0) return { synced: 0, conflicts: 0, stillPending: 0, results: [] };
 
-        let results;
-        try {
-            results = await submitEvents(pending.map(({ client_event_id, employee_id, event_type, recorded_at }) => ({
-                client_event_id,
-                employee_id,
-                event_type,
-                recorded_at,
-            })));
-        } catch (error) {
-            // Sin red o el servidor no respondió — todos quedan pendientes, se reintenta después.
-            for (const event of pending) await incrementQueuedEventAttempts(event.client_event_id);
-            console.warn('flushQueue: no se pudo sincronizar (sin red o error de servidor):', error.message);
-            return { synced: 0, conflicts: 0, stillPending: pending.length, results: [] };
-        }
-
         let synced = 0;
         let conflicts = 0;
+        const allResults = [];
 
-        for (const result of results) {
-            if (result.status === 'synced' || result.status === 'duplicate') {
-                await removeQueuedEvent(result.client_event_id);
-                synced++;
-            } else {
-                await markQueuedEventConflict(result.client_event_id, result.message);
-                conflicts++;
+        for (let offset = 0; offset < pending.length; offset += MAX_BATCH_SIZE) {
+            const batch = pending.slice(offset, offset + MAX_BATCH_SIZE);
+
+            let results;
+            try {
+                results = await submitEvents(batch.map(({ client_event_id, employee_id, event_type, recorded_at }) => ({
+                    client_event_id,
+                    employee_id,
+                    event_type,
+                    recorded_at,
+                })));
+            } catch (error) {
+                // Sin red o el servidor no respondió — este lote y los restantes (todavía no
+                // enviados) quedan pendientes para el próximo intento.
+                for (const event of pending.slice(offset)) await incrementQueuedEventAttempts(event.client_event_id);
+                console.warn(`flushQueue: no se pudo sincronizar el lote (${batch.length} de ${pending.length - offset} restantes):`, error.message);
+                break;
             }
+
+            for (const result of results) {
+                if (result.status === 'synced' || result.status === 'duplicate') {
+                    await removeQueuedEvent(result.client_event_id);
+                    synced++;
+                } else {
+                    await markQueuedEventConflict(result.client_event_id, result.message);
+                    conflicts++;
+                }
+            }
+            allResults.push(...results);
         }
 
-        return { synced, conflicts, stillPending: await countPendingEvents(), results };
+        return { synced, conflicts, stillPending: await countPendingEvents(), results: allResults };
     } finally {
         flushInProgress = false;
     }

--- a/resources/js/attendances/terminal-offline/sync.js
+++ b/resources/js/attendances/terminal-offline/sync.js
@@ -10,7 +10,7 @@
  *               ver TerminalSetupController / terminal-setup.blade.php).
  */
 
-import { getMeta, setMeta, applyEmployeesDelta, logSync } from './db.js';
+import { getMeta, setMeta, applyEmployeesDelta, logSync, countPendingEvents, countConflictEvents } from './db.js';
 
 const API_BASE = '/api/v1/terminal';
 
@@ -73,12 +73,20 @@ export async function syncEmployees() {
 
 /**
  * Heartbeat: mantiene `last_seen_at` vivo en el servidor y refresca la
- * configuración de reconocimiento facial (umbral/gap) usada por el matcher local.
+ * configuración de reconocimiento facial (umbral/gap) usada por el matcher
+ * local. También reporta el tamaño actual de la cola offline (pendientes/en
+ * conflicto) — así un admin puede detectar en Filament un terminal cuya cola
+ * no se vacía, aunque el heartbeat en sí llegue con normalidad (ver
+ * `Terminal::sync_queue_status`).
  * @returns {Promise<void>}
  */
 export async function heartbeat() {
     try {
-        const data = await apiFetch('/heartbeat', { method: 'POST' });
+        const [pendingEvents, conflictEvents] = await Promise.all([countPendingEvents(), countConflictEvents()]);
+        const data = await apiFetch('/heartbeat', {
+            method: 'POST',
+            body: JSON.stringify({ pending_events: pendingEvents, conflict_events: conflictEvents }),
+        });
         if (!data.ok) throw new Error(data.message || 'Error en heartbeat');
 
         await setMeta('face_threshold', data.config.face_threshold);
@@ -105,8 +113,8 @@ export async function getFaceConfig() {
 
 /**
  * Estado del día (último evento / eventos permitidos) para un empleado ya
- * identificado localmente. Requiere red — en esta fase la marcación sigue
- * siendo síncrona/online, esto no se resuelve desde la caché local todavía.
+ * identificado localmente. Requiere red — el caller (`queue.js`,
+ * `getEmployeeStatus()`) cae a una resolución local si esta consulta falla.
  * @param {number} employeeId
  * @returns {Promise<{last_event: string|null, last_event_time: string|null, allowed_events: string[]}>}
  */

--- a/resources/js/attendances/terminal.js
+++ b/resources/js/attendances/terminal.js
@@ -1078,6 +1078,24 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     /**
+     * Pide al navegador que la cuota de almacenamiento de este origen sea
+     * "persistente" — reduce el riesgo de que el navegador borre IndexedDB
+     * (empleados cacheados, cola de marcaciones pendientes) bajo presión de
+     * espacio en disco. Best-effort: no todos los navegadores lo soportan, y
+     * la concesión depende de heurísticas del navegador (ej. Chrome la
+     * otorga más fácil en un dispositivo instalado como PWA/kiosko).
+     */
+    async function requestPersistentStorage() {
+        if (!navigator.storage?.persist) return;
+        try {
+            const granted = await navigator.storage.persist();
+            console.log(granted ? "Almacenamiento persistente concedido" : "Almacenamiento persistente no concedido (best-effort)");
+        } catch (error) {
+            console.warn("No se pudo solicitar almacenamiento persistente:", error.message);
+        }
+    }
+
+    /**
      * Migra el token de configuración (si venía de localStorage, ver
      * terminal-setup.blade.php) y hace la primera sincronización antes de
      * arrancar el reposo. Si el terminal no está provisionado, no bloquea el
@@ -1093,6 +1111,8 @@ document.addEventListener("DOMContentLoaded", () => {
             updateIdleSyncStatus("Terminal sin configurar");
             return;
         }
+
+        await requestPersistentStorage();
 
         try {
             updateIdleSyncStatus("Sincronizando...");

--- a/tests/Feature/TerminalConnectivityTest.php
+++ b/tests/Feature/TerminalConnectivityTest.php
@@ -93,3 +93,51 @@ it('el sync de eventos actualiza last_event_sync_at', function () {
     $terminal->refresh();
     expect($terminal->last_event_sync_at)->not->toBeNull();
 });
+
+it('sin pendientes ni conflictos reportados, la cola de sync es ok', function () {
+    $terminal = makeConnectivityTerminal();
+
+    expect($terminal->sync_queue_status)->toBe('ok');
+});
+
+it('con pendientes y sin conflictos, la cola de sync es pending', function () {
+    $terminal = makeConnectivityTerminal();
+    $terminal->update(['last_pending_events_count' => 3, 'last_conflict_events_count' => 0]);
+
+    expect($terminal->fresh()->sync_queue_status)->toBe('pending');
+});
+
+it('con al menos un conflicto, la cola de sync es conflict aunque también haya pendientes', function () {
+    $terminal = makeConnectivityTerminal();
+    $terminal->update(['last_pending_events_count' => 3, 'last_conflict_events_count' => 1]);
+
+    expect($terminal->fresh()->sync_queue_status)->toBe('conflict');
+});
+
+it('el heartbeat guarda los contadores de cola que reporta el kiosko', function () {
+    $terminal = makeConnectivityTerminal();
+    Sanctum::actingAs($terminal, [Terminal::SYNC_ABILITY]);
+
+    $response = $this->postJson('/api/v1/terminal/heartbeat', [
+        'pending_events' => 5,
+        'conflict_events' => 2,
+    ]);
+
+    $response->assertOk()->assertJson(['ok' => true]);
+    $terminal->refresh();
+    expect($terminal->last_pending_events_count)->toBe(5)
+        ->and($terminal->last_conflict_events_count)->toBe(2)
+        ->and($terminal->sync_queue_status)->toBe('conflict');
+});
+
+it('el heartbeat sin contadores no rompe y deja los contadores en null', function () {
+    $terminal = makeConnectivityTerminal();
+    Sanctum::actingAs($terminal, [Terminal::SYNC_ABILITY]);
+
+    $response = $this->postJson('/api/v1/terminal/heartbeat');
+
+    $response->assertOk()->assertJson(['ok' => true]);
+    $terminal->refresh();
+    expect($terminal->last_pending_events_count)->toBeNull()
+        ->and($terminal->last_conflict_events_count)->toBeNull();
+});


### PR DESCRIPTION
## Resumen

Sexta y última fase de la marcación offline vía PWA del kiosko/terminal (ver Fases 1–5: PR #77, #78, #79, #80, #81). Se le consultó al usuario qué incluir de la Fase 6 original (agrupaba varios ítems heterogéneos) — eligió las tres: hardening técnico, runbook de revocación/reprovisión, y prueba de carga de la cola offline.

### Hardening técnico

- `navigator.storage.persist()` — reduce el riesgo de que el navegador purgue IndexedDB (empleados cacheados, cola de marcaciones) bajo presión de espacio en disco.
- **Corrección de deriva de reloj**: `server_clock_offset_ms` se calculaba en cada heartbeat desde la Fase 3 pero nunca se usaba (confirmado por grep — código muerto). Ahora corrige `recorded_at` al encolar una marcación y la resolución local de "hoy" en `resolveEmployeeStatus()`.
- **Visibilidad de la cola de sync en Filament**: el heartbeat ahora reporta `pending_events`/`conflict_events`. Nuevo `Terminal::sync_queue_status` (`ok`/`pending`/`conflict`), columna/filtro/infolist en `TerminalResource` — cierra el gap identificado al cierre de la Fase 5 (un kiosko puede verse "en línea" y aun así tener la cola atascada).
- **Fix de un bug real encontrado por la prueba de carga**: `flushQueue()` mandaba toda la cola pendiente en un solo `POST /events/sync`, pero el servidor limita el batch a 200 eventos (`TerminalEventSyncController`). Con más de 200 pendientes, el envío se rechazaba entero (422) y la cola quedaba atascada indefinidamente — cada reintento posterior fallaba igual. Se agregó chunking en `flushQueue()`.

### Runbook

`docs/runbook-terminal-revocacion-reprovision.md` — pasos para revocar el token de un terminal perdido/robado, reprovisionar, verificar que funcionó, riesgos aceptados y checklist rápido.

### Prueba de carga

No se agregó como test permanente (no hay infraestructura de Playwright en CI). Verificación manual con Playwright + Vite dev server, mockeando el límite real de 200/batch:
- 250 eventos → sin el fix, fallaba entero (0 sincronizados). Con el fix: 2 requests, 250 sincronizados.
- 450 eventos con corte de red simulado a mitad del 3er lote → los primeros 400 se sincronizan y se sacan de la cola; los 50 restantes quedan pendientes; un segundo `flushQueue()` completa el resto sin duplicar ni perder nada.

## Test plan

- [x] `tests/Feature/TerminalConnectivityTest.php` — 5 tests nuevos: los 3 estados de `sync_queue_status`, que el heartbeat persiste los contadores, y que un heartbeat sin contadores (cliente viejo) no rompe nada.
- [x] Corrida manual equivalente contra HTTP real (`php artisan serve` + curl con Bearer token real) — 10/10 OK, sin regresión en los tests de la Fase 5.
- [x] `correctedNow()`/`enqueueMark()`/`resolveEmployeeStatus()`/`heartbeat()` verificados en navegador real (Playwright + IndexedDB real) — 6/6 OK.
- [x] Prueba de carga (250 y 450 eventos, con y sin corte de red) — 5/5 + 4/4 OK tras el fix.
- [x] `vendor/bin/pint --dirty` sin hallazgos. `npm run build` sin errores.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpZ1Zv2cgQDyg3JtqDxSVH)_